### PR TITLE
🐛 fix(types): fix type declarations

### DIFF
--- a/src/Accordion/Accordion.d.ts
+++ b/src/Accordion/Accordion.d.ts
@@ -1,20 +1,18 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface AccordionProps extends HTMLAttributes<HTMLDivElement> {
-    class?: string;
-    flush?: boolean;
-    stayOpen?: boolean;
-  }
-
-  export interface AccordionEvents {
-    toggle: CustomEvent<{ [element: any]: boolean }>;
-  }
-
-  export interface AccordionSlots {
-    default: {};
-  }
-
-  export default class Accordion extends SvelteComponent<AccordionProps, AccordionEvents, AccordionSlots> {}
+export interface AccordionProps extends HTMLAttributes<HTMLDivElement> {
+  class?: string;
+  flush?: boolean;
+  stayOpen?: boolean;
 }
+
+export interface AccordionEvents {
+  toggle: CustomEvent<{ [element: any]: boolean }>;
+}
+
+export interface AccordionSlots {
+  default: {};
+}
+
+export default class Accordion extends SvelteComponent<AccordionProps, AccordionEvents, AccordionSlots> {}

--- a/src/Accordion/index.d.ts
+++ b/src/Accordion/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Accordion } from './Accordion';

--- a/src/AccordionHeader/AccordionHeader.d.ts
+++ b/src/AccordionHeader/AccordionHeader.d.ts
@@ -1,18 +1,16 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface AccordionHeaderProps extends HTMLAttributes<HTMLHeadingElement> {}
+export interface AccordionHeaderProps extends HTMLAttributes<HTMLHeadingElement> {}
 
-  export interface AccordionHeaderEvents {}
+export interface AccordionHeaderEvents {}
 
-  export interface AccordionHeaderSlots {
-    default: {};
-  }
-
-  export default class AccordionHeader extends SvelteComponent<
-    AccordionHeaderProps,
-    AccordionHeaderEvents,
-    AccordionHeaderSlots
-  > {}
+export interface AccordionHeaderSlots {
+  default: {};
 }
+
+export default class AccordionHeader extends SvelteComponent<
+  AccordionHeaderProps,
+  AccordionHeaderEvents,
+  AccordionHeaderSlots
+> {}

--- a/src/AccordionHeader/index.d.ts
+++ b/src/AccordionHeader/index.d.ts
@@ -1,0 +1,1 @@
+export { default as AccordionHeader } from './AccordionHeader';

--- a/src/AccordionItem/AccordionItem.d.ts
+++ b/src/AccordionItem/AccordionItem.d.ts
@@ -1,25 +1,23 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface AccordionItemProps extends HTMLAttributes<HTMLDivElement> {
-    active?: boolean;
-    class?: string;
-    header?: string;
-  }
-
-  export interface AccordionItemEvents {
-    toggle: CustomEvent<void>;
-  }
-
-  export interface AccordionItemSlots {
-    default: {};
-    header: {};
-  }
-
-  export default class AccordionItem extends SvelteComponent<
-    AccordionItemProps,
-    AccordionItemEvents,
-    AccordionItemSlots
-  > {}
+export interface AccordionItemProps extends HTMLAttributes<HTMLDivElement> {
+  active?: boolean;
+  class?: string;
+  header?: string;
 }
+
+export interface AccordionItemEvents {
+  toggle: CustomEvent<void>;
+}
+
+export interface AccordionItemSlots {
+  default: {};
+  header: {};
+}
+
+export default class AccordionItem extends SvelteComponent<
+  AccordionItemProps,
+  AccordionItemEvents,
+  AccordionItemSlots
+> {}

--- a/src/AccordionItem/index.d.ts
+++ b/src/AccordionItem/index.d.ts
@@ -1,0 +1,1 @@
+export { default as AccordionItem } from './AccordionItem';

--- a/src/Alert/Alert.d.ts
+++ b/src/Alert/Alert.d.ts
@@ -1,27 +1,25 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
-  import { FadeProps } from '../Fade';
-  import { Color } from '../shared';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
+import { FadeProps } from '../Fade';
+import { Color } from '../shared';
 
-  export interface AlertProps extends HTMLAttributes<HTMLDivElement> {
-    closeAriaLabel?: string;
-    closeClassName?: string;
-    color?: Color;
-    dismissible?: boolean;
-    fade?: boolean;
-    heading?: string;
-    isOpen?: boolean;
-    toggle?: () => void;
-    transition?: FadeProps;
-  }
-
-  export interface AlertEvents {}
-
-  export interface AlertSlots {
-    default: {};
-    heading?: {};
-  }
-
-  export default class Alert extends SvelteComponent<AlertProps, AlertEvents, AlertSlots> {}
+export interface AlertProps extends HTMLAttributes<HTMLDivElement> {
+  closeAriaLabel?: string;
+  closeClassName?: string;
+  color?: Color;
+  dismissible?: boolean;
+  fade?: boolean;
+  heading?: string;
+  isOpen?: boolean;
+  toggle?: () => void;
+  transition?: FadeProps;
 }
+
+export interface AlertEvents {}
+
+export interface AlertSlots {
+  default: {};
+  heading?: {};
+}
+
+export default class Alert extends SvelteComponent<AlertProps, AlertEvents, AlertSlots> {}

--- a/src/Alert/index.d.ts
+++ b/src/Alert/index.d.ts
@@ -1,0 +1,2 @@
+export { default as Alert } from './Alert';
+export { default as UncontrolledAlert } from './UncontrolledAlert.svelte';

--- a/src/Badge/Badge.d.ts
+++ b/src/Badge/Badge.d.ts
@@ -1,19 +1,17 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAnchorAttributes } from 'svelte/elements';
-  import { Color } from '../shared';
+import { SvelteComponent } from 'svelte';
+import { HTMLAnchorAttributes } from 'svelte/elements';
+import { Color } from '../shared';
 
-  export interface BadgeProps extends HTMLAnchorAttributes {
-    color?: Color;
-    href?: string;
-    pill?: boolean;
-  }
-
-  export interface BadgeEvents {}
-
-  export interface BadgeSlots {
-    default: {};
-  }
-
-  export default class Badge extends SvelteComponent<BadgeProps, BadgeEvents, BadgeSlots> {}
+export interface BadgeProps extends HTMLAnchorAttributes {
+  color?: Color;
+  href?: string;
+  pill?: boolean;
 }
+
+export interface BadgeEvents {}
+
+export interface BadgeSlots {
+  default: {};
+}
+
+export default class Badge extends SvelteComponent<BadgeProps, BadgeEvents, BadgeSlots> {}

--- a/src/Badge/index.d.ts
+++ b/src/Badge/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Badge } from './Badge';

--- a/src/Breadcrumb/Breadcrumb.d.ts
+++ b/src/Breadcrumb/Breadcrumb.d.ts
@@ -1,17 +1,15 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface BreadcrumbProps extends HTMLAttributes<HTMLElement> {
-    divider?: string;
-    listClassName?: string;
-  }
-
-  export interface BreadcrumbEvents {}
-
-  export interface BreadcrumbSlots {
-    default: {};
-  }
-
-  export default class Breadcrumb extends SvelteComponent<BreadcrumbProps, BreadcrumbEvents, BreadcrumbSlots> {}
+export interface BreadcrumbProps extends HTMLAttributes<HTMLElement> {
+  divider?: string;
+  listClassName?: string;
 }
+
+export interface BreadcrumbEvents {}
+
+export interface BreadcrumbSlots {
+  default: {};
+}
+
+export default class Breadcrumb extends SvelteComponent<BreadcrumbProps, BreadcrumbEvents, BreadcrumbSlots> {}

--- a/src/Breadcrumb/index.d.ts
+++ b/src/Breadcrumb/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Breadcrumb } from './Breadcrumb';

--- a/src/BreadcrumbItem/BreadcrumbItem.d.ts
+++ b/src/BreadcrumbItem/BreadcrumbItem.d.ts
@@ -1,20 +1,18 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLLiAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLLiAttributes } from 'svelte/elements';
 
-  export interface BreadcrumbItemProps extends HTMLLiAttributes {
-    active?: boolean;
-  }
-
-  export interface BreadcrumbItemEvents {}
-
-  export interface BreadcrumbItemSlots {
-    default: {};
-  }
-
-  export default class BreadcrumbItem extends SvelteComponent<
-    BreadcrumbItemProps,
-    BreadcrumbItemEvents,
-    BreadcrumbItemSlots
-  > {}
+export interface BreadcrumbItemProps extends HTMLLiAttributes {
+  active?: boolean;
 }
+
+export interface BreadcrumbItemEvents {}
+
+export interface BreadcrumbItemSlots {
+  default: {};
+}
+
+export default class BreadcrumbItem extends SvelteComponent<
+  BreadcrumbItemProps,
+  BreadcrumbItemEvents,
+  BreadcrumbItemSlots
+> {}

--- a/src/BreadcrumbItem/index.d.ts
+++ b/src/BreadcrumbItem/index.d.ts
@@ -1,0 +1,1 @@
+export { default as BreadcrumbItem } from './BreadcrumbItem';

--- a/src/Button/Button.d.ts
+++ b/src/Button/Button.d.ts
@@ -1,32 +1,30 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLButtonAttributes } from 'svelte/elements';
-  import { Color } from '../shared';
+import { SvelteComponent } from 'svelte';
+import { HTMLButtonAttributes } from 'svelte/elements';
+import { Color } from '../shared';
 
-  declare type ButtonColor = Color | 'link';
+declare type ButtonColor = Color | 'link';
 
-  declare type ButtonSize = 'lg' | 'sm';
+declare type ButtonSize = 'lg' | 'sm';
 
-  export interface ButtonProps extends HTMLButtonAttributes {
-    active?: boolean;
-    block?: boolean;
-    class?: string;
-    close?: boolean;
-    color?: ButtonColor;
-    disabled?: boolean;
-    href?: string;
-    inner?: HTMLElement;
-    outline?: boolean;
-    size?: ButtonSize;
-  }
-
-  export interface ButtonEvents {
-    click: WindowEventMap['click'];
-  }
-
-  export interface ButtonSlots {
-    default: {};
-  }
-
-  export default class Button extends SvelteComponent<ButtonProps, ButtonEvents, ButtonSlots> {}
+export interface ButtonProps extends HTMLButtonAttributes {
+  active?: boolean;
+  block?: boolean;
+  class?: string;
+  close?: boolean;
+  color?: ButtonColor;
+  disabled?: boolean;
+  href?: string;
+  inner?: HTMLElement;
+  outline?: boolean;
+  size?: ButtonSize;
 }
+
+export interface ButtonEvents {
+  click: WindowEventMap['click'];
+}
+
+export interface ButtonSlots {
+  default: {};
+}
+
+export default class Button extends SvelteComponent<ButtonProps, ButtonEvents, ButtonSlots> {}

--- a/src/Button/index.d.ts
+++ b/src/Button/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Button } from './Button';

--- a/src/Button/index.d.ts
+++ b/src/Button/index.d.ts
@@ -1,1 +1,1 @@
-export { default as Button } from './Button';
+export { default as Button, ButtonProps } from './Button';

--- a/src/ButtonDropdown/ButtonDropdown.d.ts
+++ b/src/ButtonDropdown/ButtonDropdown.d.ts
@@ -1,18 +1,16 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { DropdownProps } from '../Dropdown';
+import { SvelteComponent } from 'svelte';
+import { DropdownProps } from '../Dropdown';
 
-  export interface ButtonDropdownProps extends Omit<DropdownProps, 'group'> {}
+export interface ButtonDropdownProps extends Omit<DropdownProps, 'group'> {}
 
-  export interface ButtonDropdownEvents {}
+export interface ButtonDropdownEvents {}
 
-  export interface ButtonDropdownSlots {
-    default: {};
-  }
-
-  export default class ButtonDropdown extends SvelteComponent<
-    ButtonDropdownProps,
-    ButtonDropdownEvents,
-    ButtonDropdownSlots
-  > {}
+export interface ButtonDropdownSlots {
+  default: {};
 }
+
+export default class ButtonDropdown extends SvelteComponent<
+  ButtonDropdownProps,
+  ButtonDropdownEvents,
+  ButtonDropdownSlots
+> {}

--- a/src/ButtonDropdown/index.d.ts
+++ b/src/ButtonDropdown/index.d.ts
@@ -1,0 +1,1 @@
+export { default as ButtonDropdown } from './ButtonDropdown';

--- a/src/ButtonGroup/ButtonGroup.d.ts
+++ b/src/ButtonGroup/ButtonGroup.d.ts
@@ -1,17 +1,15 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface ButtonGroupProps extends HTMLAttributes<HTMLDivElement> {
-    size?: string;
-    vertical?: boolean;
-  }
-
-  export interface ButtonGroupEvents {}
-
-  export interface ButtonGroupSlots {
-    default: {};
-  }
-
-  export default class ButtonGroup extends SvelteComponent<ButtonGroupProps, ButtonGroupEvents, ButtonGroupSlots> {}
+export interface ButtonGroupProps extends HTMLAttributes<HTMLDivElement> {
+  size?: string;
+  vertical?: boolean;
 }
+
+export interface ButtonGroupEvents {}
+
+export interface ButtonGroupSlots {
+  default: {};
+}
+
+export default class ButtonGroup extends SvelteComponent<ButtonGroupProps, ButtonGroupEvents, ButtonGroupSlots> {}

--- a/src/ButtonGroup/index.d.ts
+++ b/src/ButtonGroup/index.d.ts
@@ -1,0 +1,1 @@
+export { default as ButtonGroup } from './ButtonGroup';

--- a/src/ButtonToolbar/ButtonToolbar.d.ts
+++ b/src/ButtonToolbar/ButtonToolbar.d.ts
@@ -1,18 +1,16 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface ButtonToolbarProps extends HTMLAttributes<HTMLDivElement> {}
+export interface ButtonToolbarProps extends HTMLAttributes<HTMLDivElement> {}
 
-  export interface ButtonToolbarEvents {}
+export interface ButtonToolbarEvents {}
 
-  export interface ButtonToolbarSlots {
-    default: {};
-  }
-
-  export default class ButtonToolbar extends SvelteComponent<
-    ButtonToolbarProps,
-    ButtonToolbarEvents,
-    ButtonToolbarSlots
-  > {}
+export interface ButtonToolbarSlots {
+  default: {};
 }
+
+export default class ButtonToolbar extends SvelteComponent<
+  ButtonToolbarProps,
+  ButtonToolbarEvents,
+  ButtonToolbarSlots
+> {}

--- a/src/ButtonToolbar/index.d.ts
+++ b/src/ButtonToolbar/index.d.ts
@@ -1,0 +1,1 @@
+export { default as ButtonToolbar } from './ButtonToolbar';

--- a/src/Card/Card.d.ts
+++ b/src/Card/Card.d.ts
@@ -1,6 +1,6 @@
 import { SvelteComponent } from 'svelte';
 import { HTMLAttributes } from 'svelte/elements';
-import { Color } from './shared';
+import { Color } from '../shared';
 
 export interface CardProps extends HTMLAttributes<HTMLDivElement> {
   color?: Color;

--- a/src/Card/Card.d.ts
+++ b/src/Card/Card.d.ts
@@ -1,20 +1,18 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
-  import { Color } from './shared';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
+import { Color } from './shared';
 
-  export interface CardProps extends HTMLAttributes<HTMLDivElement> {
-    color?: Color;
-    body?: boolean;
-    inverse?: boolean;
-    outline?: boolean;
-  }
-
-  export interface CardEvents {}
-
-  export interface CardSlots {
-    default: {};
-  }
-
-  export default class Card extends SvelteComponent<CardProps, CardEvents, CardSlots> {}
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  color?: Color;
+  body?: boolean;
+  inverse?: boolean;
+  outline?: boolean;
 }
+
+export interface CardEvents {}
+
+export interface CardSlots {
+  default: {};
+}
+
+export default class Card extends SvelteComponent<CardProps, CardEvents, CardSlots> {}

--- a/src/Card/index.d.ts
+++ b/src/Card/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Card } from './Card';

--- a/src/CardBody/CardBody.d.ts
+++ b/src/CardBody/CardBody.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface CardBodyProps extends HTMLAttributes<HTMLDivElement> {}
+export interface CardBodyProps extends HTMLAttributes<HTMLDivElement> {}
 
-  export interface CardBodyEvents {}
+export interface CardBodyEvents {}
 
-  export interface CardBodySlots {
-    default: {};
-  }
-
-  export default class CardBody extends SvelteComponent<CardBodyProps, CardBodyEvents, CardBodySlots> {}
+export interface CardBodySlots {
+  default: {};
 }
+
+export default class CardBody extends SvelteComponent<CardBodyProps, CardBodyEvents, CardBodySlots> {}

--- a/src/CardBody/index.d.ts
+++ b/src/CardBody/index.d.ts
@@ -1,0 +1,1 @@
+export { default as CardBody } from './CardBody';

--- a/src/CardColumns/CardColumns.d.ts
+++ b/src/CardColumns/CardColumns.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface CardColumnsProps extends HTMLAttributes<HTMLDivElement> {}
+export interface CardColumnsProps extends HTMLAttributes<HTMLDivElement> {}
 
-  export interface CardColumnsEvents {}
+export interface CardColumnsEvents {}
 
-  export interface CardColumnsSlots {
-    default: {};
-  }
-
-  export default class CardColumns extends SvelteComponent<CardColumnsProps, CardColumnsEvents, CardColumnsSlots> {}
+export interface CardColumnsSlots {
+  default: {};
 }
+
+export default class CardColumns extends SvelteComponent<CardColumnsProps, CardColumnsEvents, CardColumnsSlots> {}

--- a/src/CardColumns/index.d.ts
+++ b/src/CardColumns/index.d.ts
@@ -1,0 +1,1 @@
+export { default as CardColumns } from './CardColumns';

--- a/src/CardDeck/CardDeck.d.ts
+++ b/src/CardDeck/CardDeck.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface CardDeckProps extends HTMLAttributes<HTMLDivElement> {}
+export interface CardDeckProps extends HTMLAttributes<HTMLDivElement> {}
 
-  export interface CardDeckEvents {}
+export interface CardDeckEvents {}
 
-  export interface CardDeckSlots {
-    default: {};
-  }
-
-  export default class CardDeck extends SvelteComponent<CardDeckProps, CardDeckEvents, CardDeckSlots> {}
+export interface CardDeckSlots {
+  default: {};
 }
+
+export default class CardDeck extends SvelteComponent<CardDeckProps, CardDeckEvents, CardDeckSlots> {}

--- a/src/CardDeck/index.d.ts
+++ b/src/CardDeck/index.d.ts
@@ -1,0 +1,1 @@
+export { default as CardDeck } from './CardDeck';

--- a/src/CardFooter/CardFooter.d.ts
+++ b/src/CardFooter/CardFooter.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface CardFooterProps extends HTMLAttributes<HTMLDivElement> {}
+export interface CardFooterProps extends HTMLAttributes<HTMLDivElement> {}
 
-  export interface CardFooterEvents {}
+export interface CardFooterEvents {}
 
-  export interface CardFooterSlots {
-    default: {};
-  }
-
-  export default class CardFooter extends SvelteComponent<CardFooterProps, CardFooterEvents, CardFooterSlots> {}
+export interface CardFooterSlots {
+  default: {};
 }
+
+export default class CardFooter extends SvelteComponent<CardFooterProps, CardFooterEvents, CardFooterSlots> {}

--- a/src/CardFooter/index.d.ts
+++ b/src/CardFooter/index.d.ts
@@ -1,0 +1,1 @@
+export { default as CardFooter } from './CardFooter';

--- a/src/CardGroup/CardGroup.d.ts
+++ b/src/CardGroup/CardGroup.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface CardGroupProps extends HTMLAttributes<HTMLDivElement> {}
+export interface CardGroupProps extends HTMLAttributes<HTMLDivElement> {}
 
-  export interface CardGroupEvents {}
+export interface CardGroupEvents {}
 
-  export interface CardGroupSlots {
-    default: {};
-  }
-
-  export default class CardGroup extends SvelteComponent<CardGroupProps, CardGroupEvents, CardGroupSlots> {}
+export interface CardGroupSlots {
+  default: {};
 }
+
+export default class CardGroup extends SvelteComponent<CardGroupProps, CardGroupEvents, CardGroupSlots> {}

--- a/src/CardGroup/index.d.ts
+++ b/src/CardGroup/index.d.ts
@@ -1,0 +1,1 @@
+export { default as CardGroup } from './CardGroup';

--- a/src/CardHeader/CardHeader.d.ts
+++ b/src/CardHeader/CardHeader.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface CardHeaderProps extends HTMLAttributes<HTMLElement> {
-    tag?: 'div' | 'h3';
-  }
-
-  export interface CardHeaderEvents {}
-
-  export interface CardHeaderSlots {}
-
-  export default class CardHeader extends SvelteComponent<CardHeaderProps, CardHeaderEvents, CardHeaderSlots> {}
+export interface CardHeaderProps extends HTMLAttributes<HTMLElement> {
+  tag?: 'div' | 'h3';
 }
+
+export interface CardHeaderEvents {}
+
+export interface CardHeaderSlots {}
+
+export default class CardHeader extends SvelteComponent<CardHeaderProps, CardHeaderEvents, CardHeaderSlots> {}

--- a/src/CardHeader/index.d.ts
+++ b/src/CardHeader/index.d.ts
@@ -1,0 +1,1 @@
+export { default as CardHeader } from './CardHeader';

--- a/src/CardImg/CardImg.d.ts
+++ b/src/CardImg/CardImg.d.ts
@@ -1,15 +1,13 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLImgAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLImgAttributes } from 'svelte/elements';
 
-  export interface CardImgProps extends HTMLImgAttributes {
-    bottom?: boolean;
-    top?: boolean;
-  }
-
-  export interface CardImgEvents {}
-
-  export interface CardImgSlots {}
-
-  export default class CardImg extends SvelteComponent<CardImgProps, CardImgEvents, CardImgSlots> {}
+export interface CardImgProps extends HTMLImgAttributes {
+  bottom?: boolean;
+  top?: boolean;
 }
+
+export interface CardImgEvents {}
+
+export interface CardImgSlots {}
+
+export default class CardImg extends SvelteComponent<CardImgProps, CardImgEvents, CardImgSlots> {}

--- a/src/CardImg/index.d.ts
+++ b/src/CardImg/index.d.ts
@@ -1,0 +1,1 @@
+export { default as CardImg } from './CardImg';

--- a/src/CardImgOverlay/CardImgOverlay.d.ts
+++ b/src/CardImgOverlay/CardImgOverlay.d.ts
@@ -1,18 +1,16 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface CardImgOverlayProps extends HTMLAttributes<HTMLHeadingElement> {}
+export interface CardImgOverlayProps extends HTMLAttributes<HTMLHeadingElement> {}
 
-  export interface CardImgOverlayEvents {}
+export interface CardImgOverlayEvents {}
 
-  export interface CardImgOverlaySlots {
-    default: {};
-  }
-
-  export default class CardImgOverlay extends SvelteComponent<
-    CardImgOverlayProps,
-    CardImgOverlayEvents,
-    CardImgOverlaySlots
-  > {}
+export interface CardImgOverlaySlots {
+  default: {};
 }
+
+export default class CardImgOverlay extends SvelteComponent<
+  CardImgOverlayProps,
+  CardImgOverlayEvents,
+  CardImgOverlaySlots
+> {}

--- a/src/CardImgOverlay/index.d.ts
+++ b/src/CardImgOverlay/index.d.ts
@@ -1,0 +1,1 @@
+export { default as CardImgOverlay } from './CardImgOverlay';

--- a/src/CardLink/CardLink.d.ts
+++ b/src/CardLink/CardLink.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAnchorAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAnchorAttributes } from 'svelte/elements';
 
-  export interface CardLinkProps extends HTMLAnchorAttributes {}
+export interface CardLinkProps extends HTMLAnchorAttributes {}
 
-  export interface CardLinkEvents {}
+export interface CardLinkEvents {}
 
-  export interface CardLinkSlots {
-    default: {};
-  }
-
-  export default class CardLink extends SvelteComponent<CardLinkProps, CardLinkEvents, CardLinkSlots> {}
+export interface CardLinkSlots {
+  default: {};
 }
+
+export default class CardLink extends SvelteComponent<CardLinkProps, CardLinkEvents, CardLinkSlots> {}

--- a/src/CardLink/index.d.ts
+++ b/src/CardLink/index.d.ts
@@ -1,0 +1,1 @@
+export { default as CardLink } from './CardLink';

--- a/src/CardSubtitle/CardSubtitle.d.ts
+++ b/src/CardSubtitle/CardSubtitle.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface CardSubtitleProps extends HTMLAttributes<HTMLHeadingElement> {}
+export interface CardSubtitleProps extends HTMLAttributes<HTMLHeadingElement> {}
 
-  export interface CardSubtitleEvents {}
+export interface CardSubtitleEvents {}
 
-  export interface CardSubtitleSlots {
-    default: {};
-  }
-
-  export default class CardSubtitle extends SvelteComponent<CardSubtitleProps, CardSubtitleEvents, CardSubtitleSlots> {}
+export interface CardSubtitleSlots {
+  default: {};
 }
+
+export default class CardSubtitle extends SvelteComponent<CardSubtitleProps, CardSubtitleEvents, CardSubtitleSlots> {}

--- a/src/CardSubtitle/index.d.ts
+++ b/src/CardSubtitle/index.d.ts
@@ -1,0 +1,1 @@
+export { default as CardSubtitle } from './CardSubtitle';

--- a/src/CardText/CardText.d.ts
+++ b/src/CardText/CardText.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface CardTextProps extends HTMLAttributes<HTMLParagraphElement> {}
+export interface CardTextProps extends HTMLAttributes<HTMLParagraphElement> {}
 
-  export interface CardTextEvents {}
+export interface CardTextEvents {}
 
-  export interface CardTextSlots {
-    default: {};
-  }
-
-  export default class CardText extends SvelteComponent<CardTextProps, CardTextEvents, CardTextSlots> {}
+export interface CardTextSlots {
+  default: {};
 }
+
+export default class CardText extends SvelteComponent<CardTextProps, CardTextEvents, CardTextSlots> {}

--- a/src/CardText/index.d.ts
+++ b/src/CardText/index.d.ts
@@ -1,0 +1,1 @@
+export { default as CardText } from './CardText';

--- a/src/CardTitle/CardTitle.d.ts
+++ b/src/CardTitle/CardTitle.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface CardTitleProps extends HTMLAttributes<HTMLHeadingElement> {}
+export interface CardTitleProps extends HTMLAttributes<HTMLHeadingElement> {}
 
-  export interface CardTitleEvents {}
+export interface CardTitleEvents {}
 
-  export interface CardTitleSlots {
-    default: {};
-  }
-
-  export default class CardTitle extends SvelteComponent<CardTitleProps, CardTitleEvents, CardTitleSlots> {}
+export interface CardTitleSlots {
+  default: {};
 }
+
+export default class CardTitle extends SvelteComponent<CardTitleProps, CardTitleEvents, CardTitleSlots> {}

--- a/src/CardTitle/index.d.ts
+++ b/src/CardTitle/index.d.ts
@@ -1,0 +1,1 @@
+export { default as CardTitle } from './CardTitle';

--- a/src/Carousel/Carousel.d.ts
+++ b/src/Carousel/Carousel.d.ts
@@ -1,21 +1,19 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface CarouselProps extends HTMLAttributes<HTMLDivElement> {
-    activeIndex?: number;
-    interval?: number | string | boolean;
-    items: any[];
-    keyboard?: boolean;
-    pause?: 'hover' | false;
-    ride?: boolean;
-  }
-
-  export interface CarouselEvents {}
-
-  export interface CarouselSlots {
-    default: {};
-  }
-
-  export default class Carousel extends SvelteComponent<CarouselProps, CarouselEvents, CarouselSlots> {}
+export interface CarouselProps extends HTMLAttributes<HTMLDivElement> {
+  activeIndex?: number;
+  interval?: number | string | boolean;
+  items: any[];
+  keyboard?: boolean;
+  pause?: 'hover' | false;
+  ride?: boolean;
 }
+
+export interface CarouselEvents {}
+
+export interface CarouselSlots {
+  default: {};
+}
+
+export default class Carousel extends SvelteComponent<CarouselProps, CarouselEvents, CarouselSlots> {}

--- a/src/Carousel/index.d.ts
+++ b/src/Carousel/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Carousel } from './Carousel';

--- a/src/CarouselCaption/CarouselCaption.d.ts
+++ b/src/CarouselCaption/CarouselCaption.d.ts
@@ -1,21 +1,19 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface CarouselCaptionProps extends HTMLAttributes<HTMLDivElement> {
-    captionHeader?: string;
-    captionText: string;
-  }
-
-  export interface CarouselCaptionEvents {}
-
-  export interface CarouselCaptionSlots {
-    default: {};
-  }
-
-  export default class CarouselCaption extends SvelteComponent<
-    CarouselCaptionProps,
-    CarouselCaptionEvents,
-    CarouselCaptionSlots
-  > {}
+export interface CarouselCaptionProps extends HTMLAttributes<HTMLDivElement> {
+  captionHeader?: string;
+  captionText: string;
 }
+
+export interface CarouselCaptionEvents {}
+
+export interface CarouselCaptionSlots {
+  default: {};
+}
+
+export default class CarouselCaption extends SvelteComponent<
+  CarouselCaptionProps,
+  CarouselCaptionEvents,
+  CarouselCaptionSlots
+> {}

--- a/src/CarouselCaption/index.d.ts
+++ b/src/CarouselCaption/index.d.ts
@@ -1,0 +1,1 @@
+export { default as CarouselCaption } from './CarouselCaption';

--- a/src/CarouselControl/CarouselControl.d.ts
+++ b/src/CarouselControl/CarouselControl.d.ts
@@ -1,22 +1,20 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAnchorAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAnchorAttributes } from 'svelte/elements';
 
-  export interface CarouselControlProps extends HTMLAnchorAttributes {
-    activeIndex?: number;
-    direction: 'prev' | 'next';
-    directionText?: string;
-    items?: any[];
-    wrap?: boolean;
-  }
-
-  export interface CarouselControlEvents {}
-
-  export interface CarouselControlSlots {}
-
-  export default class CarouselControl extends SvelteComponent<
-    CarouselControlProps,
-    CarouselControlEvents,
-    CarouselControlSlots
-  > {}
+export interface CarouselControlProps extends HTMLAnchorAttributes {
+  activeIndex?: number;
+  direction: 'prev' | 'next';
+  directionText?: string;
+  items?: any[];
+  wrap?: boolean;
 }
+
+export interface CarouselControlEvents {}
+
+export interface CarouselControlSlots {}
+
+export default class CarouselControl extends SvelteComponent<
+  CarouselControlProps,
+  CarouselControlEvents,
+  CarouselControlSlots
+> {}

--- a/src/CarouselControl/index.d.ts
+++ b/src/CarouselControl/index.d.ts
@@ -1,0 +1,1 @@
+export { default as CarouselControl } from './CarouselControl';

--- a/src/CarouselIndicators/CarouselIndicators.d.ts
+++ b/src/CarouselIndicators/CarouselIndicators.d.ts
@@ -1,19 +1,17 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLOlAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLOlAttributes } from 'svelte/elements';
 
-  export interface CarouselIndicatorsProps extends HTMLOlAttributes {
-    activeIndex: number;
-    items: any[];
-  }
-
-  export interface CarouselIndicatorsEvents {}
-
-  export interface CarouselIndicatorsSlots {}
-
-  export default class CarouselIndicators extends SvelteComponent<
-    CarouselIndicatorsProps,
-    CarouselIndicatorsEvents,
-    CarouselIndicatorsSlots
-  > {}
+export interface CarouselIndicatorsProps extends HTMLOlAttributes {
+  activeIndex: number;
+  items: any[];
 }
+
+export interface CarouselIndicatorsEvents {}
+
+export interface CarouselIndicatorsSlots {}
+
+export default class CarouselIndicators extends SvelteComponent<
+  CarouselIndicatorsProps,
+  CarouselIndicatorsEvents,
+  CarouselIndicatorsSlots
+> {}

--- a/src/CarouselIndicators/index.d.ts
+++ b/src/CarouselIndicators/index.d.ts
@@ -1,0 +1,1 @@
+export { default as CarouselIndicators } from './CarouselIndicators';

--- a/src/CarouselItem/CarouselItem.d.ts
+++ b/src/CarouselItem/CarouselItem.d.ts
@@ -1,17 +1,15 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface CarouselItemProps extends HTMLAttributes<HTMLDivElement> {
-    activeIndex?: number;
-    itemIndex?: number;
-  }
-
-  export interface CarouselItemEvents {}
-
-  export interface CarouselItemSlots {
-    default: {};
-  }
-
-  export default class CarouselItem extends SvelteComponent<CarouselItemProps, CarouselItemEvents, CarouselItemSlots> {}
+export interface CarouselItemProps extends HTMLAttributes<HTMLDivElement> {
+  activeIndex?: number;
+  itemIndex?: number;
 }
+
+export interface CarouselItemEvents {}
+
+export interface CarouselItemSlots {
+  default: {};
+}
+
+export default class CarouselItem extends SvelteComponent<CarouselItemProps, CarouselItemEvents, CarouselItemSlots> {}

--- a/src/CarouselItem/index.d.ts
+++ b/src/CarouselItem/index.d.ts
@@ -1,0 +1,1 @@
+export { default as CarouselItem } from './CarouselItem';

--- a/src/Col/Col.d.ts
+++ b/src/Col/Col.d.ts
@@ -1,34 +1,32 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  declare type ColumnProps =
-    | string
-    | boolean
-    | number
-    | {
-        size?: boolean | number | string;
-        push?: string | number;
-        pull?: string | number;
-        offset?: string | number;
-        order?: string | number;
-      };
+declare type ColumnProps =
+  | string
+  | boolean
+  | number
+  | {
+      size?: boolean | number | string;
+      push?: string | number;
+      pull?: string | number;
+      offset?: string | number;
+      order?: string | number;
+    };
 
-  export interface ColProps extends HTMLAttributes<HTMLDivElement> {
-    xs?: ColumnProps;
-    sm?: ColumnProps;
-    md?: ColumnProps;
-    lg?: ColumnProps;
-    xl?: ColumnProps;
-    xxl?: ColumnProps;
-    widths?: string[];
-  }
-
-  export interface ColEvents {}
-
-  export interface ColSlots {
-    default: {};
-  }
-
-  export default class Col extends SvelteComponent<ColProps, ColEvents, ColSlots> {}
+export interface ColProps extends HTMLAttributes<HTMLDivElement> {
+  xs?: ColumnProps;
+  sm?: ColumnProps;
+  md?: ColumnProps;
+  lg?: ColumnProps;
+  xl?: ColumnProps;
+  xxl?: ColumnProps;
+  widths?: string[];
 }
+
+export interface ColEvents {}
+
+export interface ColSlots {
+  default: {};
+}
+
+export default class Col extends SvelteComponent<ColProps, ColEvents, ColSlots> {}

--- a/src/Col/index.d.ts
+++ b/src/Col/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Col } from './Col';

--- a/src/Col/index.d.ts
+++ b/src/Col/index.d.ts
@@ -1,1 +1,1 @@
-export { default as Col } from './Col';
+export { default as Col, ColProps as ColumnProps } from './Col';

--- a/src/Colgroup/Colgroup.d.ts
+++ b/src/Colgroup/Colgroup.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLColgroupAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLColgroupAttributes } from 'svelte/elements';
 
-  export interface ColgroupProps extends HTMLColgroupAttributes {}
+export interface ColgroupProps extends HTMLColgroupAttributes {}
 
-  export interface ColgroupEvents {}
+export interface ColgroupEvents {}
 
-  export interface ColgroupSlots {
-    default: {};
-  }
-
-  export default class Colgroup extends SvelteComponent<ColgroupProps, ColgroupEvents, ColgroupSlots> {}
+export interface ColgroupSlots {
+  default: {};
 }
+
+export default class Colgroup extends SvelteComponent<ColgroupProps, ColgroupEvents, ColgroupSlots> {}

--- a/src/Colgroup/index.d.ts
+++ b/src/Colgroup/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Colgroup } from './Colgroup';

--- a/src/Collapse/Collapse.d.ts
+++ b/src/Collapse/Collapse.d.ts
@@ -1,30 +1,28 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface CollapseProps extends HTMLAttributes<HTMLDivElement> {
-    expand?: boolean | string;
-    horizontal?: boolean;
-    isOpen?: boolean;
-    navbar?: boolean;
-    onEntered?: () => void;
-    onEntering?: () => void;
-    onExited?: () => void;
-    onExiting?: () => void;
-    toggler?: string;
-  }
-
-  export interface CollapseEvents {
-    close: CustomEvent<void>;
-    closing: CustomEvent<void>;
-    open: CustomEvent<void>;
-    opening: CustomEvent<void>;
-    update: CustomEvent<boolean>;
-  }
-
-  export interface CollapseSlots {
-    default: {};
-  }
-
-  export default class Collapse extends SvelteComponent<CollapseProps, CollapseEvents, CollapseSlots> {}
+export interface CollapseProps extends HTMLAttributes<HTMLDivElement> {
+  expand?: boolean | string;
+  horizontal?: boolean;
+  isOpen?: boolean;
+  navbar?: boolean;
+  onEntered?: () => void;
+  onEntering?: () => void;
+  onExited?: () => void;
+  onExiting?: () => void;
+  toggler?: string;
 }
+
+export interface CollapseEvents {
+  close: CustomEvent<void>;
+  closing: CustomEvent<void>;
+  open: CustomEvent<void>;
+  opening: CustomEvent<void>;
+  update: CustomEvent<boolean>;
+}
+
+export interface CollapseSlots {
+  default: {};
+}
+
+export default class Collapse extends SvelteComponent<CollapseProps, CollapseEvents, CollapseSlots> {}

--- a/src/Collapse/index.d.ts
+++ b/src/Collapse/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Collapse } from './Collapse';

--- a/src/Column/Column.d.ts
+++ b/src/Column/Column.d.ts
@@ -1,19 +1,17 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLTdAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLTdAttributes } from 'svelte/elements';
 
-  export interface ContainerProps extends HTMLTdAttributes {
-    footer?: string;
-    header?: string;
-  }
-
-  export interface ContainerEvents {}
-
-  export interface ContainerSlots {
-    default: {};
-    footer?: {};
-    header?: {};
-  }
-
-  export default class Container extends SvelteComponent<ContainerProps, ContainerEvents, ContainerSlots> {}
+export interface ContainerProps extends HTMLTdAttributes {
+  footer?: string;
+  header?: string;
 }
+
+export interface ContainerEvents {}
+
+export interface ContainerSlots {
+  default: {};
+  footer?: {};
+  header?: {};
+}
+
+export default class Container extends SvelteComponent<ContainerProps, ContainerEvents, ContainerSlots> {}

--- a/src/Column/index.d.ts
+++ b/src/Column/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Column } from './Column';

--- a/src/Container/Container.d.ts
+++ b/src/Container/Container.d.ts
@@ -1,22 +1,20 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface ContainerProps extends HTMLAttributes<HTMLDivElement> {
-    id?: string;
-    sm?: boolean;
-    md?: boolean;
-    lg?: boolean;
-    xl?: boolean;
-    xxl?: boolean;
-    fluid?: boolean | string;
-  }
-
-  export interface ContainerEvents {}
-
-  export interface ContainerSlots {
-    default: {};
-  }
-
-  export default class Container extends SvelteComponent<ContainerProps, ContainerEvents, ContainerSlots> {}
+export interface ContainerProps extends HTMLAttributes<HTMLDivElement> {
+  id?: string;
+  sm?: boolean;
+  md?: boolean;
+  lg?: boolean;
+  xl?: boolean;
+  xxl?: boolean;
+  fluid?: boolean | string;
 }
+
+export interface ContainerEvents {}
+
+export interface ContainerSlots {
+  default: {};
+}
+
+export default class Container extends SvelteComponent<ContainerProps, ContainerEvents, ContainerSlots> {}

--- a/src/Container/index.d.ts
+++ b/src/Container/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Container } from './Container';

--- a/src/Dropdown/Dropdown.d.ts
+++ b/src/Dropdown/Dropdown.d.ts
@@ -1,27 +1,25 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLDivElement } from 'svelte/elements';
-  import { Direction } from '../shared';
+import { SvelteComponent } from 'svelte';
+import { HTMLDivElement } from 'svelte/elements';
+import { Direction } from '../shared';
 
-  export interface DropdownItemProps extends HTMLAttributes<HTMLDivElement> {
-    active?: boolean;
-    autoClose?: boolean | string;
-    direction?: Direction;
-    dropup?: boolean;
-    group?: boolean;
-    inNavbar?: boolean;
-    isOpen?: boolean;
-    nav?: boolean;
-    setActiveFromChild?: boolean;
-    size?: string;
-    toggle?: () => void;
-  }
-
-  export interface DropdownItemEvents {}
-
-  export interface DropdownItemSlots {
-    default: {};
-  }
-
-  export default class DropdownItem extends SvelteComponent<DropdownItemProps, DropdownItemEvents, DropdownItemSlots> {}
+export interface DropdownItemProps extends HTMLAttributes<HTMLDivElement> {
+  active?: boolean;
+  autoClose?: boolean | string;
+  direction?: Direction;
+  dropup?: boolean;
+  group?: boolean;
+  inNavbar?: boolean;
+  isOpen?: boolean;
+  nav?: boolean;
+  setActiveFromChild?: boolean;
+  size?: string;
+  toggle?: () => void;
 }
+
+export interface DropdownItemEvents {}
+
+export interface DropdownItemSlots {
+  default: {};
+}
+
+export default class DropdownItem extends SvelteComponent<DropdownItemProps, DropdownItemEvents, DropdownItemSlots> {}

--- a/src/Dropdown/Dropdown.d.ts
+++ b/src/Dropdown/Dropdown.d.ts
@@ -2,7 +2,7 @@ import { SvelteComponent } from 'svelte';
 import { HTMLDivElement } from 'svelte/elements';
 import { Direction } from '../shared';
 
-export interface DropdownItemProps extends HTMLAttributes<HTMLDivElement> {
+export interface DropdownProps extends HTMLAttributes<HTMLDivElement> {
   active?: boolean;
   autoClose?: boolean | string;
   direction?: Direction;
@@ -16,10 +16,10 @@ export interface DropdownItemProps extends HTMLAttributes<HTMLDivElement> {
   toggle?: () => void;
 }
 
-export interface DropdownItemEvents {}
+export interface DropdownEvents {}
 
-export interface DropdownItemSlots {
+export interface DropdownSlots {
   default: {};
 }
 
-export default class DropdownItem extends SvelteComponent<DropdownItemProps, DropdownItemEvents, DropdownItemSlots> {}
+export default class Dropdown extends SvelteComponent<DropdownProps, DropdownEvents, DropdownSlots> {}

--- a/src/Dropdown/index.d.ts
+++ b/src/Dropdown/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Dropdown } from './Dropdown';

--- a/src/Dropdown/index.d.ts
+++ b/src/Dropdown/index.d.ts
@@ -1,1 +1,1 @@
-export { default as Dropdown, DropdownItemProps as DropdownProps } from './Dropdown';
+export { default as Dropdown, DropdownProps } from './Dropdown';

--- a/src/Dropdown/index.d.ts
+++ b/src/Dropdown/index.d.ts
@@ -1,1 +1,1 @@
-export { default as Dropdown } from './Dropdown';
+export { default as Dropdown, DropdownItemProps as DropdownProps } from './Dropdown';

--- a/src/DropdownItem/DropdownItem.d.ts
+++ b/src/DropdownItem/DropdownItem.d.ts
@@ -1,20 +1,18 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLLiAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLLiAttributes } from 'svelte/elements';
 
-  export interface DropdownItemProps extends HTMLLiAttributes {
-    active?: boolean;
-    divider?: boolean;
-    header?: boolean;
-    href?: string;
-    toggle?: boolean;
-  }
-
-  export interface DropdownItemEvents {}
-
-  export interface DropdownItemSlots {
-    default: {};
-  }
-
-  export default class DropdownItem extends SvelteComponent<DropdownItemProps, DropdownItemEvents, DropdownItemSlots> {}
+export interface DropdownItemProps extends HTMLLiAttributes {
+  active?: boolean;
+  divider?: boolean;
+  header?: boolean;
+  href?: string;
+  toggle?: boolean;
 }
+
+export interface DropdownItemEvents {}
+
+export interface DropdownItemSlots {
+  default: {};
+}
+
+export default class DropdownItem extends SvelteComponent<DropdownItemProps, DropdownItemEvents, DropdownItemSlots> {}

--- a/src/DropdownItem/index.d.ts
+++ b/src/DropdownItem/index.d.ts
@@ -1,0 +1,1 @@
+export { default as DropdownItem } from './DropdownItem';

--- a/src/DropdownMenu/DropdownMenu.d.ts
+++ b/src/DropdownMenu/DropdownMenu.d.ts
@@ -1,17 +1,15 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface DropdownMenuProps extends HTMLAttributes<HTMLUListElement> {
-    end?: boolean;
-    right?: boolean;
-  }
-
-  export interface DropdownMenuEvents {}
-
-  export interface DropdownMenuSlots {
-    default: {};
-  }
-
-  export default class DropdownMenu extends SvelteComponent<DropdownMenuProps, DropdownMenuEvents, DropdownMenuSlots> {}
+export interface DropdownMenuProps extends HTMLAttributes<HTMLUListElement> {
+  end?: boolean;
+  right?: boolean;
 }
+
+export interface DropdownMenuEvents {}
+
+export interface DropdownMenuSlots {
+  default: {};
+}
+
+export default class DropdownMenu extends SvelteComponent<DropdownMenuProps, DropdownMenuEvents, DropdownMenuSlots> {}

--- a/src/DropdownMenu/index.d.ts
+++ b/src/DropdownMenu/index.d.ts
@@ -1,0 +1,1 @@
+export { default as DropdownMenu } from './DropdownMenu';

--- a/src/DropdownToggle/DropdownToggle.d.ts
+++ b/src/DropdownToggle/DropdownToggle.d.ts
@@ -1,23 +1,21 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { ButtonProps } from './Button';
+import { SvelteComponent } from 'svelte';
+import { ButtonProps } from './Button';
 
-  export interface DropdownToggleProps extends ButtonProps {
-    caret?: boolean;
-    split?: boolean;
-    tag?: 'a' | 'div' | 'span';
-    nav?: boolean;
-  }
-
-  export interface DropdownToggleEvents {}
-
-  export interface DropdownToggleSlots {
-    default?: {};
-  }
-
-  export default class DropdownToggle extends SvelteComponent<
-    DropdownToggleProps,
-    DropdownToggleEvents,
-    DropdownToggleSlots
-  > {}
+export interface DropdownToggleProps extends ButtonProps {
+  caret?: boolean;
+  split?: boolean;
+  tag?: 'a' | 'div' | 'span';
+  nav?: boolean;
 }
+
+export interface DropdownToggleEvents {}
+
+export interface DropdownToggleSlots {
+  default?: {};
+}
+
+export default class DropdownToggle extends SvelteComponent<
+  DropdownToggleProps,
+  DropdownToggleEvents,
+  DropdownToggleSlots
+> {}

--- a/src/DropdownToggle/DropdownToggle.d.ts
+++ b/src/DropdownToggle/DropdownToggle.d.ts
@@ -1,5 +1,5 @@
 import { SvelteComponent } from 'svelte';
-import { ButtonProps } from './Button';
+import { ButtonProps } from '../Button';
 
 export interface DropdownToggleProps extends ButtonProps {
   caret?: boolean;

--- a/src/DropdownToggle/index.d.ts
+++ b/src/DropdownToggle/index.d.ts
@@ -1,0 +1,1 @@
+export { default as DropdownToggle } from './DropdownToggle';

--- a/src/Fade/Fade.d.ts
+++ b/src/Fade/Fade.d.ts
@@ -1,26 +1,24 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface FadeProps extends HTMLAttributes<HTMLDivElement> {
-    isOpen?: boolean;
-    onEntering?: () => void;
-    onEntered?: () => void;
-    onExiting?: () => void;
-    onExited?: () => void;
-    toggler?: string;
-  }
-
-  export interface FadeEvents {
-    open: CustomEvent<void>;
-    opening: CustomEvent<void>;
-    closing: CustomEvent<void>;
-    close: CustomEvent<void>;
-  }
-
-  export interface FadeSlots {
-    default: {};
-  }
-
-  export default class Fade extends SvelteComponent<FadeProps, FadeEvents, FadeSlots> {}
+export interface FadeProps extends HTMLAttributes<HTMLDivElement> {
+  isOpen?: boolean;
+  onEntering?: () => void;
+  onEntered?: () => void;
+  onExiting?: () => void;
+  onExited?: () => void;
+  toggler?: string;
 }
+
+export interface FadeEvents {
+  open: CustomEvent<void>;
+  opening: CustomEvent<void>;
+  closing: CustomEvent<void>;
+  close: CustomEvent<void>;
+}
+
+export interface FadeSlots {
+  default: {};
+}
+
+export default class Fade extends SvelteComponent<FadeProps, FadeEvents, FadeSlots> {}

--- a/src/Fade/index.d.ts
+++ b/src/Fade/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Fade } from './Fade';

--- a/src/Fade/index.d.ts
+++ b/src/Fade/index.d.ts
@@ -1,1 +1,1 @@
-export { default as Fade } from './Fade';
+export { default as Fade, FadeProps } from './Fade';

--- a/src/Figure/Figure.d.ts
+++ b/src/Figure/Figure.d.ts
@@ -1,15 +1,13 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface FigureProps extends HTMLAttributes<HTMLElement> {}
+export interface FigureProps extends HTMLAttributes<HTMLElement> {}
 
-  export interface FigureEvents {}
+export interface FigureEvents {}
 
-  export interface FigureSlots {
-    default: {};
-    caption?: {};
-  }
-
-  export default class Figure extends SvelteComponent<FigureProps, FigureEvents, FigureSlots> {}
+export interface FigureSlots {
+  default: {};
+  caption?: {};
 }
+
+export default class Figure extends SvelteComponent<FigureProps, FigureEvents, FigureSlots> {}

--- a/src/Figure/index.d.ts
+++ b/src/Figure/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Figure } from './Figure';

--- a/src/Form/Form.d.ts
+++ b/src/Form/Form.d.ts
@@ -1,17 +1,15 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLFormAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLFormAttributes } from 'svelte/elements';
 
-  export interface FormProps extends HTMLFormAttributes {
-    inline?: boolean;
-    validated?: boolean;
-  }
-
-  export interface FormEvents {}
-
-  export interface FormSlots {
-    default: {};
-  }
-
-  export default class Form extends SvelteComponent<FormProps, FormEvents, FormSlots> {}
+export interface FormProps extends HTMLFormAttributes {
+  inline?: boolean;
+  validated?: boolean;
 }
+
+export interface FormEvents {}
+
+export interface FormSlots {
+  default: {};
+}
+
+export default class Form extends SvelteComponent<FormProps, FormEvents, FormSlots> {}

--- a/src/Form/index.d.ts
+++ b/src/Form/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Form } from './Form';

--- a/src/FormCheck/FormCheck.d.ts
+++ b/src/FormCheck/FormCheck.d.ts
@@ -1,24 +1,22 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLInputAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLInputAttributes } from 'svelte/elements';
 
-  export interface FormCheckProps extends HTMLInputAttributes {
-    group?: any;
-    inline?: boolean;
-    inner?: HTMLElement;
-    invalid?: boolean;
-    label?: string;
-    reverse?: boolean;
-    size?: 'lg' | 'sm';
-    valid?: boolean;
-  }
-
-  export interface FormCheckEvents {}
-
-  export interface FormCheckSlots {
-    default: {};
-    label?: {};
-  }
-
-  export default class FormCheck extends SvelteComponent<FormCheckProps, FormCheckEvents, FormCheckSlots> {}
+export interface FormCheckProps extends HTMLInputAttributes {
+  group?: any;
+  inline?: boolean;
+  inner?: HTMLElement;
+  invalid?: boolean;
+  label?: string;
+  reverse?: boolean;
+  size?: 'lg' | 'sm';
+  valid?: boolean;
 }
+
+export interface FormCheckEvents {}
+
+export interface FormCheckSlots {
+  default: {};
+  label?: {};
+}
+
+export default class FormCheck extends SvelteComponent<FormCheckProps, FormCheckEvents, FormCheckSlots> {}

--- a/src/FormCheck/index.d.ts
+++ b/src/FormCheck/index.d.ts
@@ -1,0 +1,1 @@
+export { default as FormCheck } from './FormCheck';

--- a/src/FormFeedback/FormFeedback.d.ts
+++ b/src/FormFeedback/FormFeedback.d.ts
@@ -1,17 +1,15 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface FormFeedbackProps extends HTMLAttributes<HTMLDivElement> {
-    tooltip?: boolean;
-    valid?: boolean;
-  }
-
-  export interface FormFeedbackEvents {}
-
-  export interface FormFeedbackSlots {
-    default: {};
-  }
-
-  export default class FormFeedback extends SvelteComponent<FormFeedbackProps, FormFeedbackEvents, FormFeedbackSlots> {}
+export interface FormFeedbackProps extends HTMLAttributes<HTMLDivElement> {
+  tooltip?: boolean;
+  valid?: boolean;
 }
+
+export interface FormFeedbackEvents {}
+
+export interface FormFeedbackSlots {
+  default: {};
+}
+
+export default class FormFeedback extends SvelteComponent<FormFeedbackProps, FormFeedbackEvents, FormFeedbackSlots> {}

--- a/src/FormFeedback/index.d.ts
+++ b/src/FormFeedback/index.d.ts
@@ -1,0 +1,1 @@
+export { default as FormFeedback } from './FormFeedback';

--- a/src/FormGroup/FormGroup.d.ts
+++ b/src/FormGroup/FormGroup.d.ts
@@ -1,23 +1,21 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface FormGroupProps extends HTMLAttributes<HTMLDivElement> {
-    check?: boolean;
-    disabled?: boolean;
-    floating?: boolean;
-    inline?: boolean;
-    label?: string;
-    row?: boolean;
-    tag?: 'div' | 'fieldset';
-  }
-
-  export interface FormGroupEvents {}
-
-  export interface FormGroupSlots {
-    default: {};
-    label: {};
-  }
-
-  export default class FormGroup extends SvelteComponent<FormGroupProps, FormGroupEvents, FormGroupSlots> {}
+export interface FormGroupProps extends HTMLAttributes<HTMLDivElement> {
+  check?: boolean;
+  disabled?: boolean;
+  floating?: boolean;
+  inline?: boolean;
+  label?: string;
+  row?: boolean;
+  tag?: 'div' | 'fieldset';
 }
+
+export interface FormGroupEvents {}
+
+export interface FormGroupSlots {
+  default: {};
+  label: {};
+}
+
+export default class FormGroup extends SvelteComponent<FormGroupProps, FormGroupEvents, FormGroupSlots> {}

--- a/src/FormGroup/index.d.ts
+++ b/src/FormGroup/index.d.ts
@@ -1,0 +1,1 @@
+export { default as FormGroup } from './FormGroup';

--- a/src/FormText/FormText.d.ts
+++ b/src/FormText/FormText.d.ts
@@ -1,18 +1,16 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
-  import { TextColor } from '../shared';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
+import { TextColor } from '../shared';
 
-  export interface IconProps extends HTMLAttributes<HTMLElement> {
-    color?: TextColor;
-    inline?: boolean;
-  }
-
-  export interface IconEvents {}
-
-  export interface IconSlots {
-    default: {};
-  }
-
-  export default class Icon extends SvelteComponent<IconProps, IconEvents, IconSlots> {}
+export interface IconProps extends HTMLAttributes<HTMLElement> {
+  color?: TextColor;
+  inline?: boolean;
 }
+
+export interface IconEvents {}
+
+export interface IconSlots {
+  default: {};
+}
+
+export default class Icon extends SvelteComponent<IconProps, IconEvents, IconSlots> {}

--- a/src/FormText/index.d.ts
+++ b/src/FormText/index.d.ts
@@ -1,0 +1,1 @@
+export { default as FormText } from './FormText';

--- a/src/Icon/Icon.d.ts
+++ b/src/Icon/Icon.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface IconProps extends HTMLAttributes<HTMLElement> {
-    name: string;
-  }
-
-  export interface IconEvents {}
-
-  export interface IconSlots {}
-
-  export default class Icon extends SvelteComponent<IconProps, IconEvents, IconSlots> {}
+export interface IconProps extends HTMLAttributes<HTMLElement> {
+  name: string;
 }
+
+export interface IconEvents {}
+
+export interface IconSlots {}
+
+export default class Icon extends SvelteComponent<IconProps, IconEvents, IconSlots> {}

--- a/src/Icon/index.d.ts
+++ b/src/Icon/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Icon } from './Icon';

--- a/src/Image/Image.d.ts
+++ b/src/Image/Image.d.ts
@@ -1,17 +1,15 @@
-declare module 'svetlestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLImgAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLImgAttributes } from 'svelte/elements';
 
-  export interface ImageProps extends HTMLImgAttributes {
-    alt?: string;
-    figure?: boolean;
-    fluid?: boolean;
-    thumbnail?: boolean;
-  }
-
-  export interface ImageEvents {}
-
-  export interface ImageSlots {}
-
-  export default class Image extends SvelteComponent<ImageProps, ImageEvents, ImageSlots> {}
+export interface ImageProps extends HTMLImgAttributes {
+  alt?: string;
+  figure?: boolean;
+  fluid?: boolean;
+  thumbnail?: boolean;
 }
+
+export interface ImageEvents {}
+
+export interface ImageSlots {}
+
+export default class Image extends SvelteComponent<ImageProps, ImageEvents, ImageSlots> {}

--- a/src/Image/index.d.ts
+++ b/src/Image/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Image } from './Image';

--- a/src/InlineContainer/InlineContainer.d.ts
+++ b/src/InlineContainer/InlineContainer.d.ts
@@ -1,18 +1,16 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface InlineContainerProps extends HTMLAttributes<HTMLDivElement> {}
+export interface InlineContainerProps extends HTMLAttributes<HTMLDivElement> {}
 
-  export interface InlineContainerEvents {}
+export interface InlineContainerEvents {}
 
-  export interface InlineContainerSlots {
-    default: {};
-  }
-
-  export default class InlineContainer extends SvelteComponent<
-    InlineContainerProps,
-    InlineContainerEvents,
-    InlineContainerSlots
-  > {}
+export interface InlineContainerSlots {
+  default: {};
 }
+
+export default class InlineContainer extends SvelteComponent<
+  InlineContainerProps,
+  InlineContainerEvents,
+  InlineContainerSlots
+> {}

--- a/src/InlineContainer/index.d.ts
+++ b/src/InlineContainer/index.d.ts
@@ -1,0 +1,1 @@
+export { default as InlineContainer } from './InlineContainer';

--- a/src/Input/Input.d.ts
+++ b/src/Input/Input.d.ts
@@ -1,27 +1,25 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLInputAttributes } from 'svelte/elements';
-  import { Color } from '../shared';
+import { SvelteComponent } from 'svelte';
+import { HTMLInputAttributes } from 'svelte/elements';
+import { Color } from '../shared';
 
-  export interface InputProps extends HTMLInputAttributes {
-    bsSize?: 'lg' | 'sm';
-    color?: Color;
-    feedback?: string | string[];
-    files?: FileList;
-    group?: any;
-    inner?: HTMLElement;
-    invalid?: boolean;
-    label?: string;
-    plaintext?: boolean;
-    reverse?: boolean;
-    valid?: boolean;
-  }
-
-  export interface InputEvents {}
-
-  export interface InputSlots {
-    default?: {};
-  }
-
-  export default class Input extends SvelteComponent<InputProps, InputEvents, InputSlots> {}
+export interface InputProps extends HTMLInputAttributes {
+  bsSize?: 'lg' | 'sm';
+  color?: Color;
+  feedback?: string | string[];
+  files?: FileList;
+  group?: any;
+  inner?: HTMLElement;
+  invalid?: boolean;
+  label?: string;
+  plaintext?: boolean;
+  reverse?: boolean;
+  valid?: boolean;
 }
+
+export interface InputEvents {}
+
+export interface InputSlots {
+  default?: {};
+}
+
+export default class Input extends SvelteComponent<InputProps, InputEvents, InputSlots> {}

--- a/src/Input/index.d.ts
+++ b/src/Input/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Input } from './Input';

--- a/src/InputGroup/InputGroup.d.ts
+++ b/src/InputGroup/InputGroup.d.ts
@@ -1,16 +1,14 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface InputGroupProps extends HTMLAttributes<HTMLDivElement> {
-    size?: 'sm' | 'lg';
-  }
-
-  export interface InputGroupEvents {}
-
-  export interface InputGroupSlots {
-    default: {};
-  }
-
-  export default class InputGroup extends SvelteComponent<InputGroupProps, InputGroupEvents, InputGroupSlots> {}
+export interface InputGroupProps extends HTMLAttributes<HTMLDivElement> {
+  size?: 'sm' | 'lg';
 }
+
+export interface InputGroupEvents {}
+
+export interface InputGroupSlots {
+  default: {};
+}
+
+export default class InputGroup extends SvelteComponent<InputGroupProps, InputGroupEvents, InputGroupSlots> {}

--- a/src/InputGroup/index.d.ts
+++ b/src/InputGroup/index.d.ts
@@ -1,0 +1,1 @@
+export { default as InputGroup } from './InputGroup';

--- a/src/InputGroupText/InputGroupText.d.ts
+++ b/src/InputGroupText/InputGroupText.d.ts
@@ -1,18 +1,16 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface InputGroupTextProps extends HTMLAttributes<HTMLSpanElement> {}
+export interface InputGroupTextProps extends HTMLAttributes<HTMLSpanElement> {}
 
-  export interface InputGroupTextEvents {}
+export interface InputGroupTextEvents {}
 
-  export interface InputGroupTextSlots {
-    default: {};
-  }
-
-  export default class InputGroupText extends SvelteComponent<
-    InputGroupTextProps,
-    InputGroupTextEvents,
-    InputGroupTextSlots
-  > {}
+export interface InputGroupTextSlots {
+  default: {};
 }
+
+export default class InputGroupText extends SvelteComponent<
+  InputGroupTextProps,
+  InputGroupTextEvents,
+  InputGroupTextSlots
+> {}

--- a/src/InputGroupText/index.d.ts
+++ b/src/InputGroupText/index.d.ts
@@ -1,0 +1,1 @@
+export { default as InputGroupText } from './InputGroupText';

--- a/src/Jumbotron/Jumbotron.d.ts
+++ b/src/Jumbotron/Jumbotron.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface JumbotronProps extends HTMLAttributes<HTMLDivElement> {}
+export interface JumbotronProps extends HTMLAttributes<HTMLDivElement> {}
 
-  export interface JumbotronEvents {}
+export interface JumbotronEvents {}
 
-  export interface JumbotronSlots {
-    default: {};
-  }
-
-  export default class Jumbotron extends SvelteComponent<JumbotronProps, JumbotronEvents, JumbotronSlots> {}
+export interface JumbotronSlots {
+  default: {};
 }
+
+export default class Jumbotron extends SvelteComponent<JumbotronProps, JumbotronEvents, JumbotronSlots> {}

--- a/src/Jumbotron/index.d.ts
+++ b/src/Jumbotron/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Jumbotron } from './Jumbotron';

--- a/src/Label/Label.d.ts
+++ b/src/Label/Label.d.ts
@@ -1,25 +1,23 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLLabelAttributes } from 'svelte/elements';
-  import { ColumnProps } from '../Col';
+import { SvelteComponent } from 'svelte';
+import { HTMLLabelAttributes } from 'svelte/elements';
+import { ColumnProps } from '../Col';
 
-  export interface LabelProps extends HTMLLabelAttributes {
-    check?: boolean;
-    hidden?: boolean;
-    lg?: ColumnProps;
-    md?: ColumnProps;
-    size?: string;
-    sm?: ColumnProps;
-    xl?: ColumnProps;
-    xs?: ColumnProps;
-    xxl?: ColumnProps;
-  }
-
-  export interface LabelEvents {}
-
-  export interface LabelSlots {
-    default: {};
-  }
-
-  export default class Label extends SvelteComponent<LabelProps, LabelEvents, LabelSlots> {}
+export interface LabelProps extends HTMLLabelAttributes {
+  check?: boolean;
+  hidden?: boolean;
+  lg?: ColumnProps;
+  md?: ColumnProps;
+  size?: string;
+  sm?: ColumnProps;
+  xl?: ColumnProps;
+  xs?: ColumnProps;
+  xxl?: ColumnProps;
 }
+
+export interface LabelEvents {}
+
+export interface LabelSlots {
+  default: {};
+}
+
+export default class Label extends SvelteComponent<LabelProps, LabelEvents, LabelSlots> {}

--- a/src/Label/index.d.ts
+++ b/src/Label/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Label } from './Label';

--- a/src/ListGroup/ListGroup.d.ts
+++ b/src/ListGroup/ListGroup.d.ts
@@ -1,18 +1,16 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface ListGroupProps extends HTMLAttributes<HTMLUListElement> {
-    flush?: boolean;
-    horizontal?: boolean;
-    numbered?: boolean;
-  }
-
-  export interface ListGroupEvents {}
-
-  export interface ListGroupSlots {
-    default: {};
-  }
-
-  export default class ListGroup extends SvelteComponent<ListGroupProps, ListGroupEvents, ListGroupSlots> {}
+export interface ListGroupProps extends HTMLAttributes<HTMLUListElement> {
+  flush?: boolean;
+  horizontal?: boolean;
+  numbered?: boolean;
 }
+
+export interface ListGroupEvents {}
+
+export interface ListGroupSlots {
+  default: {};
+}
+
+export default class ListGroup extends SvelteComponent<ListGroupProps, ListGroupEvents, ListGroupSlots> {}

--- a/src/ListGroup/index.d.ts
+++ b/src/ListGroup/index.d.ts
@@ -1,0 +1,1 @@
+export { default as ListGroup } from './ListGroup';

--- a/src/ListGroupItem/ListGroupItem.d.ts
+++ b/src/ListGroupItem/ListGroupItem.d.ts
@@ -1,31 +1,29 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAnchorAttributes } from 'svelte/elements';
-  import { Color } from '../shared';
+import { SvelteComponent } from 'svelte';
+import { HTMLAnchorAttributes } from 'svelte/elements';
+import { Color } from '../shared';
 
-  export interface ListGroupItemProps extends HTMLAnchorAttributes {
-    action?: boolean;
-    active?: boolean;
-    color?: Color;
-    disabled?: boolean;
-    href?: string;
-    tag?: 'a' | 'button' | 'li';
-  }
-
-  export interface ListGroupItemEvents {
-    open: CustomEvent<void>;
-    opening: CustomEvent<void>;
-    closing: CustomEvent<void>;
-    close: CustomEvent<void>;
-  }
-
-  export interface ListGroupItemSlots {
-    default: {};
-  }
-
-  export default class ListGroupItem extends SvelteComponent<
-    ListGroupItemProps,
-    ListGroupItemEvents,
-    ListGroupItemSlots
-  > {}
+export interface ListGroupItemProps extends HTMLAnchorAttributes {
+  action?: boolean;
+  active?: boolean;
+  color?: Color;
+  disabled?: boolean;
+  href?: string;
+  tag?: 'a' | 'button' | 'li';
 }
+
+export interface ListGroupItemEvents {
+  open: CustomEvent<void>;
+  opening: CustomEvent<void>;
+  closing: CustomEvent<void>;
+  close: CustomEvent<void>;
+}
+
+export interface ListGroupItemSlots {
+  default: {};
+}
+
+export default class ListGroupItem extends SvelteComponent<
+  ListGroupItemProps,
+  ListGroupItemEvents,
+  ListGroupItemSlots
+> {}

--- a/src/ListGroupItem/index.d.ts
+++ b/src/ListGroupItem/index.d.ts
@@ -1,0 +1,1 @@
+export { default as ListGroupItem } from './ListGroupItem';

--- a/src/Modal/Modal.d.ts
+++ b/src/Modal/Modal.d.ts
@@ -1,43 +1,41 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
-  import type { FadeProps } from '../Fade';
-  import type { Breakpoints, ContainerType } from '../shared';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
+import type { FadeProps } from '../Fade';
+import type { Breakpoints, ContainerType } from '../shared';
 
-  export interface ModalProps extends HTMLAttributes<HTMLDivElement> {
-    autoFocus?: boolean;
-    backdrop?: boolean | 'static';
-    body?: boolean;
-    centered?: boolean;
-    container?: ContainerType;
-    contentClassName?: string;
-    fade?: boolean;
-    fullscreen?: boolean | Breakpoints;
-    header?: string;
-    isOpen?: boolean;
-    keyboard?: boolean;
-    labelledBy?: string;
-    modalClassName?: string;
-    returnFocusAfterClose?: boolean;
-    scrollable?: boolean;
-    size?: string;
-    toggle?: () => void;
-    unmountOnClose?: boolean;
-    wrapClassName?: string;
-    zIndex?: number | string;
-  }
-
-  export interface ModalEvents {
-    open: CustomEvent<void>;
-    opening: CustomEvent<void>;
-    closing: CustomEvent<void>;
-    close: CustomEvent<void>;
-  }
-
-  export interface ModalSlots {
-    default: {};
-    external: {};
-  }
-
-  export default class Modal extends SvelteComponent<ModalProps, ModalEvents, ModalSlots> {}
+export interface ModalProps extends HTMLAttributes<HTMLDivElement> {
+  autoFocus?: boolean;
+  backdrop?: boolean | 'static';
+  body?: boolean;
+  centered?: boolean;
+  container?: ContainerType;
+  contentClassName?: string;
+  fade?: boolean;
+  fullscreen?: boolean | Breakpoints;
+  header?: string;
+  isOpen?: boolean;
+  keyboard?: boolean;
+  labelledBy?: string;
+  modalClassName?: string;
+  returnFocusAfterClose?: boolean;
+  scrollable?: boolean;
+  size?: string;
+  toggle?: () => void;
+  unmountOnClose?: boolean;
+  wrapClassName?: string;
+  zIndex?: number | string;
 }
+
+export interface ModalEvents {
+  open: CustomEvent<void>;
+  opening: CustomEvent<void>;
+  closing: CustomEvent<void>;
+  close: CustomEvent<void>;
+}
+
+export interface ModalSlots {
+  default: {};
+  external: {};
+}
+
+export default class Modal extends SvelteComponent<ModalProps, ModalEvents, ModalSlots> {}

--- a/src/Modal/index.d.ts
+++ b/src/Modal/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Modal } from './Modal';

--- a/src/ModalBackdrop/ModalBackdrop.d.ts
+++ b/src/ModalBackdrop/ModalBackdrop.d.ts
@@ -1,21 +1,19 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface ModalBackdropProps extends HTMLAttributes<HTMLDivElement> {
-    fade?: boolean;
-    isOpen?: boolean;
-  }
-
-  export interface ModalBackdropEvents {}
-
-  export interface ModalBackdropSlots {
-    default: {};
-  }
-
-  export default class ModalBackdrop extends SvelteComponent<
-    ModalBackdropProps,
-    ModalBackdropEvents,
-    ModalBackdropSlots
-  > {}
+export interface ModalBackdropProps extends HTMLAttributes<HTMLDivElement> {
+  fade?: boolean;
+  isOpen?: boolean;
 }
+
+export interface ModalBackdropEvents {}
+
+export interface ModalBackdropSlots {
+  default: {};
+}
+
+export default class ModalBackdrop extends SvelteComponent<
+  ModalBackdropProps,
+  ModalBackdropEvents,
+  ModalBackdropSlots
+> {}

--- a/src/ModalBackdrop/index.d.ts
+++ b/src/ModalBackdrop/index.d.ts
@@ -1,0 +1,1 @@
+export { default as ModalBackdrop } from './ModalBackdrop';

--- a/src/ModalBody/ModalBody.d.ts
+++ b/src/ModalBody/ModalBody.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface ModalHeaderProps extends HTMLAttributes<HTMLDivElement> {}
+export interface ModalHeaderProps extends HTMLAttributes<HTMLDivElement> {}
 
-  export interface ModalHeaderEvents {}
+export interface ModalHeaderEvents {}
 
-  export interface ModalHeaderSlots {
-    default: {};
-  }
-
-  export default class ModalHeader extends SvelteComponent<ModalHeaderProps, ModalHeaderEvents, ModalHeaderSlots> {}
+export interface ModalHeaderSlots {
+  default: {};
 }
+
+export default class ModalHeader extends SvelteComponent<ModalHeaderProps, ModalHeaderEvents, ModalHeaderSlots> {}

--- a/src/ModalBody/index.d.ts
+++ b/src/ModalBody/index.d.ts
@@ -1,0 +1,1 @@
+export { default as ModalBody } from './ModalBody';

--- a/src/ModalFooter/ModalFooter.d.ts
+++ b/src/ModalFooter/ModalFooter.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface ModalFooterProps extends HTMLAttributes<HTMLDivElement> {}
+export interface ModalFooterProps extends HTMLAttributes<HTMLDivElement> {}
 
-  export interface ModalFooterEvents {}
+export interface ModalFooterEvents {}
 
-  export interface ModalFooterSlots {
-    default: {};
-  }
-
-  export default class ModalFooter extends SvelteComponent<ModalFooterProps, ModalFooterEvents, ModalFooterSlots> {}
+export interface ModalFooterSlots {
+  default: {};
 }
+
+export default class ModalFooter extends SvelteComponent<ModalFooterProps, ModalFooterEvents, ModalFooterSlots> {}

--- a/src/ModalFooter/index.d.ts
+++ b/src/ModalFooter/index.d.ts
@@ -1,0 +1,1 @@
+export { default as ModalFooter } from './ModalFooter';

--- a/src/ModalHeader/ModalHeader.d.ts
+++ b/src/ModalHeader/ModalHeader.d.ts
@@ -1,17 +1,15 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface ModalHeaderProps extends HTMLAttributes<HTMLDivElement> {
-    ariaToggle?: string;
-    toggle?: () => void;
-  }
-
-  export interface ModalHeaderEvents {}
-
-  export interface ModalHeaderSlots {
-    default: {};
-  }
-
-  export default class ModalHeader extends SvelteComponent<ModalHeaderProps, ModalHeaderEvents, ModalHeaderSlots> {}
+export interface ModalHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  ariaToggle?: string;
+  toggle?: () => void;
 }
+
+export interface ModalHeaderEvents {}
+
+export interface ModalHeaderSlots {
+  default: {};
+}
+
+export default class ModalHeader extends SvelteComponent<ModalHeaderProps, ModalHeaderEvents, ModalHeaderSlots> {}

--- a/src/ModalHeader/index.d.ts
+++ b/src/ModalHeader/index.d.ts
@@ -1,0 +1,1 @@
+export { default as ModalHeader } from './ModalHeader';

--- a/src/Nav/Nav.d.ts
+++ b/src/Nav/Nav.d.ts
@@ -1,24 +1,22 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface NavProps extends HTMLAttributes<HTMLUListElement> {
-    card?: boolean;
-    fill?: boolean;
-    horizontal?: string;
-    justified?: boolean;
-    navbar?: boolean;
-    pills?: boolean;
-    tabs?: boolean;
-    vertical?: boolean | string;
-    underline?: boolean;
-  }
-
-  export interface NavEvents {}
-
-  export interface NavSlots {
-    default: {};
-  }
-
-  export default class Nav extends SvelteComponent<NavProps, NavEvents, NavSlots> {}
+export interface NavProps extends HTMLAttributes<HTMLUListElement> {
+  card?: boolean;
+  fill?: boolean;
+  horizontal?: string;
+  justified?: boolean;
+  navbar?: boolean;
+  pills?: boolean;
+  tabs?: boolean;
+  vertical?: boolean | string;
+  underline?: boolean;
 }
+
+export interface NavEvents {}
+
+export interface NavSlots {
+  default: {};
+}
+
+export default class Nav extends SvelteComponent<NavProps, NavEvents, NavSlots> {}

--- a/src/Nav/index.d.ts
+++ b/src/Nav/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Nav } from './Nav';

--- a/src/NavItem/NavItem.d.ts
+++ b/src/NavItem/NavItem.d.ts
@@ -1,16 +1,14 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLLiAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLLiAttributes } from 'svelte/elements';
 
-  export interface NavItemProps extends HTMLLiAttributes {
-    active?: boolean;
-  }
-
-  export interface NavItemEvents {}
-
-  export interface NavItemSlots {
-    default: {};
-  }
-
-  export default class NavItem extends SvelteComponent<NavItemProps, NavItemEvents, NavItemSlots> {}
+export interface NavItemProps extends HTMLLiAttributes {
+  active?: boolean;
 }
+
+export interface NavItemEvents {}
+
+export interface NavItemSlots {
+  default: {};
+}
+
+export default class NavItem extends SvelteComponent<NavItemProps, NavItemEvents, NavItemSlots> {}

--- a/src/NavItem/index.d.ts
+++ b/src/NavItem/index.d.ts
@@ -1,0 +1,1 @@
+export { default as NavItem } from './NavItem';

--- a/src/NavLink/NavLink.d.ts
+++ b/src/NavLink/NavLink.d.ts
@@ -1,19 +1,17 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAnchorAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAnchorAttributes } from 'svelte/elements';
 
-  export interface NavLinkProps extends HTMLAnchorAttributes {
-    active?: boolean;
-    disabled?: boolean;
-  }
-
-  export interface NavLinkEvents {
-    click: WindowEventMap['click'];
-  }
-
-  export interface NavLinkSlots {
-    default: {};
-  }
-
-  export default class NavLink extends SvelteComponent<NavLinkProps, NavLinkEvents, NavLinkSlots> {}
+export interface NavLinkProps extends HTMLAnchorAttributes {
+  active?: boolean;
+  disabled?: boolean;
 }
+
+export interface NavLinkEvents {
+  click: WindowEventMap['click'];
+}
+
+export interface NavLinkSlots {
+  default: {};
+}
+
+export default class NavLink extends SvelteComponent<NavLinkProps, NavLinkEvents, NavLinkSlots> {}

--- a/src/NavLink/index.d.ts
+++ b/src/NavLink/index.d.ts
@@ -1,0 +1,1 @@
+export { default as NavLink } from './NavLink';

--- a/src/Navbar/Navbar.d.ts
+++ b/src/Navbar/Navbar.d.ts
@@ -1,23 +1,21 @@
-declare module sveltestrap {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
-  import { BackgroundColor } from '../shared';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
+import { BackgroundColor } from '../shared';
 
-  export interface NavbarProps extends HTMLAttributes<HTMLElement> {
-    color?: BackgroundColor;
-    container?: boolean | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | 'fluid';
-    dark?: boolean;
-    expand?: boolean | string;
-    fixed?: string;
-    light?: boolean;
-    sticky?: string;
-  }
-
-  export interface NavbarEvents {}
-
-  export interface NavbarSlots {
-    default: {};
-  }
-
-  export default class Navbar extends SvelteComponent<NavbarProps, NavbarEvents, NavbarSlots> {}
+export interface NavbarProps extends HTMLAttributes<HTMLElement> {
+  color?: BackgroundColor;
+  container?: boolean | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | 'fluid';
+  dark?: boolean;
+  expand?: boolean | string;
+  fixed?: string;
+  light?: boolean;
+  sticky?: string;
 }
+
+export interface NavbarEvents {}
+
+export interface NavbarSlots {
+  default: {};
+}
+
+export default class Navbar extends SvelteComponent<NavbarProps, NavbarEvents, NavbarSlots> {}

--- a/src/Navbar/index.d.ts
+++ b/src/Navbar/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Navbar } from './Navbar';

--- a/src/NavbarBrand/NavbarBrand.d.ts
+++ b/src/NavbarBrand/NavbarBrand.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAnchorAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAnchorAttributes } from 'svelte/elements';
 
-  export interface NavbarBrandProps extends HTMLAnchorAttributes {}
+export interface NavbarBrandProps extends HTMLAnchorAttributes {}
 
-  export interface NavbarBrandEvents {}
+export interface NavbarBrandEvents {}
 
-  export interface NavbarBrandSlots {
-    default: {};
-  }
-
-  export default class NavbarBrand extends SvelteComponent<NavbarBrandProps, NavbarBrandEvents, NavbarBrandSlots> {}
+export interface NavbarBrandSlots {
+  default: {};
 }
+
+export default class NavbarBrand extends SvelteComponent<NavbarBrandProps, NavbarBrandEvents, NavbarBrandSlots> {}

--- a/src/NavbarBrand/index.d.ts
+++ b/src/NavbarBrand/index.d.ts
@@ -1,0 +1,1 @@
+export { default as NavbarBrand } from './NavbarBrand';

--- a/src/NavbarToggler/NavbarToggler.d.ts
+++ b/src/NavbarToggler/NavbarToggler.d.ts
@@ -1,23 +1,21 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { ButtonProps } from '../Button';
+import { SvelteComponent } from 'svelte';
+import { ButtonProps } from '../Button';
 
-  export interface NavbarTogglerProps extends ButtonProps {
-    active?: boolean;
-    disabled?: boolean;
-  }
-
-  export interface NavbarTogglerEvents {
-    click: WindowEventMap['click'];
-  }
-
-  export interface NavbarTogglerSlots {
-    default: {};
-  }
-
-  export default class NavbarToggler extends SvelteComponent<
-    NavbarTogglerProps,
-    NavbarTogglerEvents,
-    NavbarTogglerSlots
-  > {}
+export interface NavbarTogglerProps extends ButtonProps {
+  active?: boolean;
+  disabled?: boolean;
 }
+
+export interface NavbarTogglerEvents {
+  click: WindowEventMap['click'];
+}
+
+export interface NavbarTogglerSlots {
+  default: {};
+}
+
+export default class NavbarToggler extends SvelteComponent<
+  NavbarTogglerProps,
+  NavbarTogglerEvents,
+  NavbarTogglerSlots
+> {}

--- a/src/NavbarToggler/index.d.ts
+++ b/src/NavbarToggler/index.d.ts
@@ -1,0 +1,1 @@
+export { default as NavbarToggler } from './NavbarToggler';

--- a/src/Offcanvas/Offcanvas.d.ts
+++ b/src/Offcanvas/Offcanvas.d.ts
@@ -1,37 +1,35 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
-  import { ContainerType, Placement } from '../shared';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
+import { ContainerType, Placement } from '../shared';
 
-  export interface OffcanvasProps extends HTMLAttributes<HTMLDivElement> {
-    backdrop?: boolean;
-    body?: boolean;
-    container?: ContainerType;
-    fade?: boolean;
-    header?: string;
-    isOpen: boolean;
-    keyboard: boolean;
-    placement?: Placement;
-    scroll?: boolean;
-    sm?: boolean;
-    md?: boolean;
-    lg?: boolean;
-    xl?: boolean;
-    xxl?: boolean;
-    toggle?: () => void;
-  }
-
-  export interface OffcanvasEvents {
-    open: CustomEvent<void>;
-    opening: CustomEvent<void>;
-    closing: CustomEvent<void>;
-    close: CustomEvent<void>;
-  }
-
-  export interface OffcanvasSlots {
-    default: {};
-    header: {};
-  }
-
-  export default class Offcanvas extends SvelteComponent<OffcanvasProps, OffcanvasEvents, OffcanvasSlots> {}
+export interface OffcanvasProps extends HTMLAttributes<HTMLDivElement> {
+  backdrop?: boolean;
+  body?: boolean;
+  container?: ContainerType;
+  fade?: boolean;
+  header?: string;
+  isOpen: boolean;
+  keyboard: boolean;
+  placement?: Placement;
+  scroll?: boolean;
+  sm?: boolean;
+  md?: boolean;
+  lg?: boolean;
+  xl?: boolean;
+  xxl?: boolean;
+  toggle?: () => void;
 }
+
+export interface OffcanvasEvents {
+  open: CustomEvent<void>;
+  opening: CustomEvent<void>;
+  closing: CustomEvent<void>;
+  close: CustomEvent<void>;
+}
+
+export interface OffcanvasSlots {
+  default: {};
+  header: {};
+}
+
+export default class Offcanvas extends SvelteComponent<OffcanvasProps, OffcanvasEvents, OffcanvasSlots> {}

--- a/src/Offcanvas/index.d.ts
+++ b/src/Offcanvas/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Offcanvas } from './Offcanvas';

--- a/src/OffcanvasBackdrop/OffcanvasBackdrop.d.ts
+++ b/src/OffcanvasBackdrop/OffcanvasBackdrop.d.ts
@@ -1,21 +1,19 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface OffcanvasBackdropProps extends HTMLAttributes<HTMLDivElement> {
-    fade?: boolean;
-    isOpen?: boolean;
-  }
-
-  export interface OffcanvasBackdropEvents {
-    click: WindowEventMap['click'];
-  }
-
-  export interface OffcanvasBackdropSlots {}
-
-  export default class OffcanvasBackdrop extends SvelteComponent<
-    OffcanvasBackdropProps,
-    OffcanvasBackdropEvents,
-    OffcanvasBackdropSlots
-  > {}
+export interface OffcanvasBackdropProps extends HTMLAttributes<HTMLDivElement> {
+  fade?: boolean;
+  isOpen?: boolean;
 }
+
+export interface OffcanvasBackdropEvents {
+  click: WindowEventMap['click'];
+}
+
+export interface OffcanvasBackdropSlots {}
+
+export default class OffcanvasBackdrop extends SvelteComponent<
+  OffcanvasBackdropProps,
+  OffcanvasBackdropEvents,
+  OffcanvasBackdropSlots
+> {}

--- a/src/OffcanvasBackdrop/index.d.ts
+++ b/src/OffcanvasBackdrop/index.d.ts
@@ -1,0 +1,1 @@
+export { default as OffcanvasBackdrop } from './OffcanvasBackdrop';

--- a/src/OffcanvasBody/OffcanvasBody.d.ts
+++ b/src/OffcanvasBody/OffcanvasBody.d.ts
@@ -1,18 +1,16 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface OffcanvasBodyProps extends HTMLAttributes<HTMLDivElement> {}
+export interface OffcanvasBodyProps extends HTMLAttributes<HTMLDivElement> {}
 
-  export interface OffcanvasBodyEvents {}
+export interface OffcanvasBodyEvents {}
 
-  export interface OffcanvasBodySlots {
-    default: {};
-  }
-
-  export default class OffcanvasBody extends SvelteComponent<
-    OffcanvasBodyProps,
-    OffcanvasBodyEvents,
-    OffcanvasBodySlots
-  > {}
+export interface OffcanvasBodySlots {
+  default: {};
 }
+
+export default class OffcanvasBody extends SvelteComponent<
+  OffcanvasBodyProps,
+  OffcanvasBodyEvents,
+  OffcanvasBodySlots
+> {}

--- a/src/OffcanvasBody/index.d.ts
+++ b/src/OffcanvasBody/index.d.ts
@@ -1,0 +1,1 @@
+export { default as OffcanvasBody } from './OffcanvasBody';

--- a/src/OffcanvasHeader/OffcanvasHeader.d.ts
+++ b/src/OffcanvasHeader/OffcanvasHeader.d.ts
@@ -1,21 +1,19 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface OffcanvasHeaderProps extends HTMLAttributes<HTMLDivElement> {
-    closeAriaLabel?: string;
-    toggle?: () => void;
-  }
-
-  export interface OffcanvasHeaderEvents {}
-
-  export interface OffcanvasHeaderSlots {
-    default: {};
-  }
-
-  export default class OffcanvasHeader extends SvelteComponent<
-    OffcanvasHeaderProps,
-    OffcanvasHeaderEvents,
-    OffcanvasHeaderSlots
-  > {}
+export interface OffcanvasHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  closeAriaLabel?: string;
+  toggle?: () => void;
 }
+
+export interface OffcanvasHeaderEvents {}
+
+export interface OffcanvasHeaderSlots {
+  default: {};
+}
+
+export default class OffcanvasHeader extends SvelteComponent<
+  OffcanvasHeaderProps,
+  OffcanvasHeaderEvents,
+  OffcanvasHeaderSlots
+> {}

--- a/src/OffcanvasHeader/index.d.ts
+++ b/src/OffcanvasHeader/index.d.ts
@@ -1,0 +1,1 @@
+export { default as OffcanvasHeader } from './OffcanvasHeader';

--- a/src/Pagination/Pagination.d.ts
+++ b/src/Pagination/Pagination.d.ts
@@ -1,18 +1,16 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface PaginationProps extends HTMLAttributes<HTMLElement> {
-    arialabel?: string;
-    listClassName?: string;
-    size?: string;
-  }
-
-  export interface PaginationEvents {}
-
-  export interface PaginationSlots {
-    default: {};
-  }
-
-  export default class Pagination extends SvelteComponent<PaginationProps, PaginationEvents, PaginationSlots> {}
+export interface PaginationProps extends HTMLAttributes<HTMLElement> {
+  arialabel?: string;
+  listClassName?: string;
+  size?: string;
 }
+
+export interface PaginationEvents {}
+
+export interface PaginationSlots {
+  default: {};
+}
+
+export default class Pagination extends SvelteComponent<PaginationProps, PaginationEvents, PaginationSlots> {}

--- a/src/Pagination/index.d.ts
+++ b/src/Pagination/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Pagination } from './Pagination';

--- a/src/PaginationItem/PaginationItem.d.ts
+++ b/src/PaginationItem/PaginationItem.d.ts
@@ -1,21 +1,19 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLLiAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLLiAttributes } from 'svelte/elements';
 
-  export interface PaginationItemProps extends HTMLLiAttributes {
-    active?: boolean;
-    disabled?: boolean;
-  }
-
-  export interface PaginationItemEvents {}
-
-  export interface PaginationItemSlots {
-    default: {};
-  }
-
-  export default class PaginationItem extends SvelteComponent<
-    PaginationItemProps,
-    PaginationItemEvents,
-    PaginationItemSlots
-  > {}
+export interface PaginationItemProps extends HTMLLiAttributes {
+  active?: boolean;
+  disabled?: boolean;
 }
+
+export interface PaginationItemEvents {}
+
+export interface PaginationItemSlots {
+  default: {};
+}
+
+export default class PaginationItem extends SvelteComponent<
+  PaginationItemProps,
+  PaginationItemEvents,
+  PaginationItemSlots
+> {}

--- a/src/PaginationItem/index.d.ts
+++ b/src/PaginationItem/index.d.ts
@@ -1,0 +1,1 @@
+export { default as PaginationItem } from './PaginationItem';

--- a/src/PaginationLink/PaginationLink.d.ts
+++ b/src/PaginationLink/PaginationLink.d.ts
@@ -1,26 +1,24 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAnchorAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAnchorAttributes } from 'svelte/elements';
 
-  export interface PaginationLinkProps extends HTMLAnchorAttributes {
-    arialabel?: string;
-    first?: boolean;
-    last?: boolean;
-    next?: boolean;
-    previous?: boolean;
-  }
-
-  export interface PaginationLinkEvents {
-    click: WindowEventMap['click'];
-  }
-
-  export interface PaginationLinkSlots {
-    default: {};
-  }
-
-  export default class PaginationLink extends SvelteComponent<
-    PaginationLinkProps,
-    PaginationLinkEvents,
-    PaginationLinkSlots
-  > {}
+export interface PaginationLinkProps extends HTMLAnchorAttributes {
+  arialabel?: string;
+  first?: boolean;
+  last?: boolean;
+  next?: boolean;
+  previous?: boolean;
 }
+
+export interface PaginationLinkEvents {
+  click: WindowEventMap['click'];
+}
+
+export interface PaginationLinkSlots {
+  default: {};
+}
+
+export default class PaginationLink extends SvelteComponent<
+  PaginationLinkProps,
+  PaginationLinkEvents,
+  PaginationLinkSlots
+> {}

--- a/src/PaginationLink/index.d.ts
+++ b/src/PaginationLink/index.d.ts
@@ -1,0 +1,1 @@
+export { default as PaginationLink } from './PaginationLink';

--- a/src/Popover/Popover.d.ts
+++ b/src/Popover/Popover.d.ts
@@ -1,29 +1,27 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
-  import { ContainerType } from '../shared';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
+import { ContainerType } from '../shared';
 
-  declare type PopoverPlacement = 'left' | 'top' | 'bottom' | 'right';
-  declare type Triggers = 'click' | 'hover' | 'focus';
+declare type PopoverPlacement = 'left' | 'top' | 'bottom' | 'right';
+declare type Triggers = 'click' | 'hover' | 'focus';
 
-  export interface PopoverProps extends HTMLAttributes<HTMLDivElement> {
-    animation?: boolean;
-    container?: ContainerType;
-    dismissible?: boolean;
-    hideOnOutsideClick?: boolean;
-    isOpen?: boolean;
-    placement?: PopoverPlacement;
-    target: string;
-    title?: string;
-    trigger?: Triggers;
-  }
-
-  export interface PopoverEvents {}
-
-  export interface PopoverSlots {
-    default: {};
-    title: {};
-  }
-
-  export default class Popover extends SvelteComponent<PopoverProps, PopoverEvents, PopoverSlots> {}
+export interface PopoverProps extends HTMLAttributes<HTMLDivElement> {
+  animation?: boolean;
+  container?: ContainerType;
+  dismissible?: boolean;
+  hideOnOutsideClick?: boolean;
+  isOpen?: boolean;
+  placement?: PopoverPlacement;
+  target: string;
+  title?: string;
+  trigger?: Triggers;
 }
+
+export interface PopoverEvents {}
+
+export interface PopoverSlots {
+  default: {};
+  title: {};
+}
+
+export default class Popover extends SvelteComponent<PopoverProps, PopoverEvents, PopoverSlots> {}

--- a/src/Popover/index.d.ts
+++ b/src/Popover/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Popover } from './Popover';

--- a/src/Portal/Portal.d.ts
+++ b/src/Portal/Portal.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface PortalProps extends HTMLAttributes<HTMLDivElement> {}
+export interface PortalProps extends HTMLAttributes<HTMLDivElement> {}
 
-  export interface PortalEvents {}
+export interface PortalEvents {}
 
-  export interface PortalSlots {
-    default: {};
-  }
-
-  export default class Portal extends SvelteComponent<PortalProps, PortalEvents, PortalSlots> {}
+export interface PortalSlots {
+  default: {};
 }
+
+export default class Portal extends SvelteComponent<PortalProps, PortalEvents, PortalSlots> {}

--- a/src/Portal/index.d.ts
+++ b/src/Portal/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Portal } from './Portal';

--- a/src/Progress/Progress.d.ts
+++ b/src/Progress/Progress.d.ts
@@ -1,24 +1,22 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
-  import { Color } from '../shared';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
+import { Color } from '../shared';
 
-  export interface ProgressProps extends HTMLAttributes<HTMLDivElement> {
-    animated?: boolean;
-    bar?: boolean;
-    barClassName?: string;
-    color?: Color;
-    max?: string | number;
-    multi?: boolean;
-    striped?: boolean;
-    value?: string | number;
-  }
-
-  export interface ProgressEvents {}
-
-  export interface ProgressSlots {
-    default: {};
-  }
-
-  export default class Progress extends SvelteComponent<ProgressProps, ProgressEvents, ProgressSlots> {}
+export interface ProgressProps extends HTMLAttributes<HTMLDivElement> {
+  animated?: boolean;
+  bar?: boolean;
+  barClassName?: string;
+  color?: Color;
+  max?: string | number;
+  multi?: boolean;
+  striped?: boolean;
+  value?: string | number;
 }
+
+export interface ProgressEvents {}
+
+export interface ProgressSlots {
+  default: {};
+}
+
+export default class Progress extends SvelteComponent<ProgressProps, ProgressEvents, ProgressSlots> {}

--- a/src/Progress/index.d.ts
+++ b/src/Progress/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Progress } from './Progress';

--- a/src/ResponsiveContainer/ResponsiveContainer.d.ts
+++ b/src/ResponsiveContainer/ResponsiveContainer.d.ts
@@ -1,19 +1,17 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
+import { SvelteComponent } from 'svelte';
 
-  export interface ResponsiveContainerProps {
-    responsive?: boolean | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
-  }
-
-  export interface ResponsiveContainerEvents {}
-
-  export interface ResponsiveContainerSlots {
-    default: {};
-  }
-
-  export default class ResponsiveContainer extends SvelteComponent<
-    ResponsiveContainerProps,
-    ResponsiveContainerEvents,
-    ResponsiveContainerSlots
-  > {}
+export interface ResponsiveContainerProps {
+  responsive?: boolean | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 }
+
+export interface ResponsiveContainerEvents {}
+
+export interface ResponsiveContainerSlots {
+  default: {};
+}
+
+export default class ResponsiveContainer extends SvelteComponent<
+  ResponsiveContainerProps,
+  ResponsiveContainerEvents,
+  ResponsiveContainerSlots
+> {}

--- a/src/ResponsiveContainer/index.d.ts
+++ b/src/ResponsiveContainer/index.d.ts
@@ -1,0 +1,1 @@
+export { default as ResponsiveContainer } from './ResponsiveContainer';

--- a/src/Row/Row.d.ts
+++ b/src/Row/Row.d.ts
@@ -1,20 +1,18 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
-  import { ColumnProps } from '../shared';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
+import { ColumnProps } from '../shared';
 
-  export interface RowProps extends HTMLAttributes<HTMLDivElement> {
-    cols?: ColumnProps;
-    noGutters?: boolean;
-    form?: boolean;
-    inner?: HTMLElement;
-  }
-
-  export interface RowEvents {}
-
-  export interface RowSlots {
-    default: {};
-  }
-
-  export default class Row extends SvelteComponent<RowProps, RowEvents, RowSlots> {}
+export interface RowProps extends HTMLAttributes<HTMLDivElement> {
+  cols?: ColumnProps;
+  noGutters?: boolean;
+  form?: boolean;
+  inner?: HTMLElement;
 }
+
+export interface RowEvents {}
+
+export interface RowSlots {
+  default: {};
+}
+
+export default class Row extends SvelteComponent<RowProps, RowEvents, RowSlots> {}

--- a/src/Row/index.d.ts
+++ b/src/Row/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Row } from './Row';

--- a/src/Spinner/Spinner.d.ts
+++ b/src/Spinner/Spinner.d.ts
@@ -1,19 +1,17 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { TextColor } from '../shared';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { TextColor } from '../shared';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface SpinnerProps extends HTMLAttributes<HTMLDivElement> {
-    color?: TextColor;
-    size?: any;
-    type?: string;
-  }
-
-  export interface SpinnerEvents {}
-
-  export interface SpinnerSlots {
-    default: {};
-  }
-
-  export default class Spinner extends SvelteComponent<SpinnerProps, SpinnerEvents, SpinnerSlots> {}
+export interface SpinnerProps extends HTMLAttributes<HTMLDivElement> {
+  color?: TextColor;
+  size?: any;
+  type?: string;
 }
+
+export interface SpinnerEvents {}
+
+export interface SpinnerSlots {
+  default: {};
+}
+
+export default class Spinner extends SvelteComponent<SpinnerProps, SpinnerEvents, SpinnerSlots> {}

--- a/src/Spinner/index.d.ts
+++ b/src/Spinner/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Spinner } from './Spinner';

--- a/src/Styles/Styles.d.ts
+++ b/src/Styles/Styles.d.ts
@@ -1,14 +1,12 @@
-declare module 'svetlestrap' {
-  import { SvelteComponent } from 'svelte';
+import { SvelteComponent } from 'svelte';
 
-  export interface StylesProps {
-    icons?: boolean;
-    theme?: 'light' | 'dark' | 'auto' | undefined;
-  }
-
-  export interface StylesEvents {}
-
-  export interface StylesSlots {}
-
-  export default class Styles extends SvelteComponent<StylesProps, StylesEvents, StylesSlots> {}
+export interface StylesProps {
+  icons?: boolean;
+  theme?: 'light' | 'dark' | 'auto' | undefined;
 }
+
+export interface StylesEvents {}
+
+export interface StylesSlots {}
+
+export default class Styles extends SvelteComponent<StylesProps, StylesEvents, StylesSlots> {}

--- a/src/Styles/index.d.ts
+++ b/src/Styles/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Styles } from './Styles';

--- a/src/TabContent/TabContent.d.ts
+++ b/src/TabContent/TabContent.d.ts
@@ -1,16 +1,14 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface TabContentProps extends HTMLAttributes<HTMLDivElement> {}
+export interface TabContentProps extends HTMLAttributes<HTMLDivElement> {}
 
-  export interface TabContentEvents {
-    tab: CustomEvent<number | string>;
-  }
-
-  export interface TabContentSlots {
-    default: {};
-  }
-
-  export default class TabContent extends SvelteComponent<TabContentProps, TabContentEvents, TabContentSlots> {}
+export interface TabContentEvents {
+  tab: CustomEvent<number | string>;
 }
+
+export interface TabContentSlots {
+  default: {};
+}
+
+export default class TabContent extends SvelteComponent<TabContentProps, TabContentEvents, TabContentSlots> {}

--- a/src/TabContent/index.d.ts
+++ b/src/TabContent/index.d.ts
@@ -1,0 +1,1 @@
+export { default as TabContent } from './TabContent';

--- a/src/TabPane/TabPane.d.ts
+++ b/src/TabPane/TabPane.d.ts
@@ -1,20 +1,18 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface TabPaneProps extends HTMLAttributes<HTMLDivElement> {
-    active?: boolean;
-    tab?: string;
-    disabled?: boolean;
-    tabId?: number | string;
-  }
-
-  export interface TabPaneEvents {}
-
-  export interface TabPaneSlots {
-    default: {};
-    tab: {};
-  }
-
-  export default class TabPane extends SvelteComponent<TabPaneProps, TabPaneEvents, TabPaneSlots> {}
+export interface TabPaneProps extends HTMLAttributes<HTMLDivElement> {
+  active?: boolean;
+  tab?: string;
+  disabled?: boolean;
+  tabId?: number | string;
 }
+
+export interface TabPaneEvents {}
+
+export interface TabPaneSlots {
+  default: {};
+  tab: {};
+}
+
+export default class TabPane extends SvelteComponent<TabPaneProps, TabPaneEvents, TabPaneSlots> {}

--- a/src/TabPane/index.d.ts
+++ b/src/TabPane/index.d.ts
@@ -1,0 +1,1 @@
+export { default as TabPane } from './TabPane';

--- a/src/Table/Table.d.ts
+++ b/src/Table/Table.d.ts
@@ -1,25 +1,23 @@
-declare module 'sveltestrap' {
-  import { Breakpoints } from '../shared';
-  import { SvelteComponent } from 'svelte';
-  import { HTMLTableAttributes } from 'svelte/elements';
+import { Breakpoints } from '../shared';
+import { SvelteComponent } from 'svelte';
+import { HTMLTableAttributes } from 'svelte/elements';
 
-  export interface TableProps<T> extends HTMLTableAttributes {
-    bordered?: boolean;
-    borderless?: boolean;
-    hover?: boolean;
-    responsive?: boolean | Breakpoints;
-    rows?: T[];
-    size?: string;
-    striped?: boolean;
-  }
-
-  export interface TableEvents {}
-
-  export interface TableSlots<T> {
-    default: {
-      row?: T;
-    };
-  }
-
-  export default class Table<T> extends SvelteComponent<TableProps<T>, TableEvents, TableSlots<T>> {}
+export interface TableProps<T> extends HTMLTableAttributes {
+  bordered?: boolean;
+  borderless?: boolean;
+  hover?: boolean;
+  responsive?: boolean | Breakpoints;
+  rows?: T[];
+  size?: string;
+  striped?: boolean;
 }
+
+export interface TableEvents {}
+
+export interface TableSlots<T> {
+  default: {
+    row?: T;
+  };
+}
+
+export default class Table<T> extends SvelteComponent<TableProps<T>, TableEvents, TableSlots<T>> {}

--- a/src/Table/index.d.ts
+++ b/src/Table/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Table } from './Table';

--- a/src/TableFooter/TableFooter.d.ts
+++ b/src/TableFooter/TableFooter.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface TableFooterProps extends HTMLAttributes<HTMLTableSectionElement> {}
+export interface TableFooterProps extends HTMLAttributes<HTMLTableSectionElement> {}
 
-  export interface TableFooterEvents {}
+export interface TableFooterEvents {}
 
-  export interface TableFooterSlots {
-    default: {};
-  }
-
-  export default class TableFooter extends SvelteComponent<TableFooterProps, TableFooterEvents, TableFooterSlots> {}
+export interface TableFooterSlots {
+  default: {};
 }
+
+export default class TableFooter extends SvelteComponent<TableFooterProps, TableFooterEvents, TableFooterSlots> {}

--- a/src/TableFooter/index.d.ts
+++ b/src/TableFooter/index.d.ts
@@ -1,0 +1,1 @@
+export { default as TableFooter } from './TableFooter';

--- a/src/TableHeader/TableHeader.d.ts
+++ b/src/TableHeader/TableHeader.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface TableHeaderProps extends HTMLAttributes<HTMLTableSectionElement> {}
+export interface TableHeaderProps extends HTMLAttributes<HTMLTableSectionElement> {}
 
-  export interface TableHeaderEvents {}
+export interface TableHeaderEvents {}
 
-  export interface TableHeaderSlots {
-    default: {};
-  }
-
-  export default class TableHeader extends SvelteComponent<TableHeaderProps, TableHeaderEvents, TableHeaderSlots> {}
+export interface TableHeaderSlots {
+  default: {};
 }
+
+export default class TableHeader extends SvelteComponent<TableHeaderProps, TableHeaderEvents, TableHeaderSlots> {}

--- a/src/TableHeader/index.d.ts
+++ b/src/TableHeader/index.d.ts
@@ -1,0 +1,1 @@
+export { default as TableHeader } from './TableHeader';

--- a/src/Toast/Toast.d.ts
+++ b/src/Toast/Toast.d.ts
@@ -1,28 +1,26 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface ToastProps extends HTMLAttributes<HTMLDivElement> {
-    autohide?: boolean;
-    body?: boolean;
-    delay?: number;
-    duration?: number;
-    fade?: boolean;
-    header?: string;
-    isOpen?: boolean;
-    toggle?: () => void;
-  }
-
-  export interface ToastEvents {
-    open: CustomEvent<void>;
-    opening: CustomEvent<void>;
-    closing: CustomEvent<void>;
-    close: CustomEvent<void>;
-  }
-
-  export interface ToastSlots {
-    default: {};
-  }
-
-  export default class Toast extends SvelteComponent<ToastProps, ToastEvents, ToastSlots> {}
+export interface ToastProps extends HTMLAttributes<HTMLDivElement> {
+  autohide?: boolean;
+  body?: boolean;
+  delay?: number;
+  duration?: number;
+  fade?: boolean;
+  header?: string;
+  isOpen?: boolean;
+  toggle?: () => void;
 }
+
+export interface ToastEvents {
+  open: CustomEvent<void>;
+  opening: CustomEvent<void>;
+  closing: CustomEvent<void>;
+  close: CustomEvent<void>;
+}
+
+export interface ToastSlots {
+  default: {};
+}
+
+export default class Toast extends SvelteComponent<ToastProps, ToastEvents, ToastSlots> {}

--- a/src/Toast/index.d.ts
+++ b/src/Toast/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Toast } from './Toast';

--- a/src/ToastBody/ToastBody.d.ts
+++ b/src/ToastBody/ToastBody.d.ts
@@ -1,14 +1,12 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface ToastBodyProps extends HTMLAttributes<HTMLDivElement> {}
+export interface ToastBodyProps extends HTMLAttributes<HTMLDivElement> {}
 
-  export interface ToastBodyEvents {}
+export interface ToastBodyEvents {}
 
-  export interface ToastBodySlots {
-    default: {};
-  }
-
-  export default class ToastBody extends SvelteComponent<ToastBodyProps, ToastBodyEvents, ToastBodySlots> {}
+export interface ToastBodySlots {
+  default: {};
 }
+
+export default class ToastBody extends SvelteComponent<ToastBodyProps, ToastBodyEvents, ToastBodySlots> {}

--- a/src/ToastBody/index.d.ts
+++ b/src/ToastBody/index.d.ts
@@ -1,0 +1,1 @@
+export { default as ToastBody } from './ToastBody';

--- a/src/ToastHeader/ToastHeader.d.ts
+++ b/src/ToastHeader/ToastHeader.d.ts
@@ -1,20 +1,18 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
 
-  export interface ToastHeaderProps extends HTMLAttributes<HTMLDivElement> {
-    toggle?: () => void;
-    icon?: any;
-    closeAriaLabel?: string;
-  }
-
-  export interface ToastHeaderEvents {}
-
-  export interface ToastHeaderSlots {
-    default: {};
-    close: {};
-    icon: {};
-  }
-
-  export default class ToastHeader extends SvelteComponent<ToastHeaderProps, ToastHeaderEvents, ToastHeaderSlots> {}
+export interface ToastHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  toggle?: () => void;
+  icon?: any;
+  closeAriaLabel?: string;
 }
+
+export interface ToastHeaderEvents {}
+
+export interface ToastHeaderSlots {
+  default: {};
+  close: {};
+  icon: {};
+}
+
+export default class ToastHeader extends SvelteComponent<ToastHeaderProps, ToastHeaderEvents, ToastHeaderSlots> {}

--- a/src/ToastHeader/index.d.ts
+++ b/src/ToastHeader/index.d.ts
@@ -1,0 +1,1 @@
+export { default as ToastHeader } from './ToastHeader';

--- a/src/Tooltip/Tooltip.d.ts
+++ b/src/Tooltip/Tooltip.d.ts
@@ -1,23 +1,21 @@
-declare module 'sveltestrap' {
-  import { SvelteComponent } from 'svelte';
-  import { HTMLAttributes } from 'svelte/elements';
-  import { ContainerType, Placement } from '../shared';
+import { SvelteComponent } from 'svelte';
+import { HTMLAttributes } from 'svelte/elements';
+import { ContainerType, Placement } from '../shared';
 
-  type TooltipPlacement = 'left' | 'top' | 'bottom' | 'right';
+type TooltipPlacement = 'left' | 'top' | 'bottom' | 'right';
 
-  export interface TooltipProps extends HTMLAttributes<HTMLDivElement> {
-    animation?: boolean;
-    container?: ContainerType;
-    isOpen?: boolean;
-    placement?: TooltipPlacement;
-    target: string | HTMLElement;
-  }
-
-  export interface TooltipEvents {}
-
-  export interface TooltipSlots {
-    default: {};
-  }
-
-  export default class Tooltip extends SvelteComponent<TooltipProps, TooltipEvents, TooltipSlots> {}
+export interface TooltipProps extends HTMLAttributes<HTMLDivElement> {
+  animation?: boolean;
+  container?: ContainerType;
+  isOpen?: boolean;
+  placement?: TooltipPlacement;
+  target: string | HTMLElement;
 }
+
+export interface TooltipEvents {}
+
+export interface TooltipSlots {
+  default: {};
+}
+
+export default class Tooltip extends SvelteComponent<TooltipProps, TooltipEvents, TooltipSlots> {}

--- a/src/Tooltip/index.d.ts
+++ b/src/Tooltip/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Tooltip } from './Tooltip';


### PR DESCRIPTION
Fixes #32

I recently switched from [bestguy/sveltestrap](https://github.com/bestguy/sveltestrap) and quickly noticed that type declarations don't work anymore. This PR should fix it. The first two commits were automated, the third fixes some leftover issues. Only declaration files are changed.

- daf67764496d86f8a72dde5f5f18e5190e42cb9f: Removes the ambient module from all declaration files, i.e. `declare module 'sveltestrap'`. This is redundant (and should be `declare module '@sveltestrap/sveltestrap'` if anything).
- 831a2d6c59a0d10b8a0e4c5b45692b6f1662f7d8: Adds index.d.ts files to all components to mirror the existing index.js files (which don't work with type declarations).
- 2253b0c6617ce8d98021d14e343b859baab109b3: Fixes remaining issues with relative imports, such as `./shared` instead of `../shared`.