### PR TITLE
🐛 fix(types): add missing HTML attributes to InputProps

### DIFF
--- a/src/Input/Input.d.ts
+++ b/src/Input/Input.d.ts
@@ -1,8 +1,8 @@
 import { SvelteComponent } from 'svelte';
-import { HTMLInputAttributes } from 'svelte/elements';
+import { HTMLInputAttributes, HTMLSelectAttributes, HTMLTextareaAttributes } from 'svelte/elements';
 import { Color } from '../shared';
 
-export interface InputProps extends HTMLInputAttributes {
+export interface InputProps extends HTMLInputAttributes, HTMLSelectAttributes, HTMLTextareaAttributes {
   bsSize?: 'lg' | 'sm';
   color?: Color;
   feedback?: string | string[];


### PR DESCRIPTION
Fixes #37

The HTML element of `<Input>` can be either `<input>`, `<select>` or `<textarea>`, but `InputProps` currently only extends  `HTMLInputAttributes`. It should also extend `HTMLSelectAttributes` and `HTMLTextareaAttributes`.