### PR TITLE
fix(types): make keyboard optional in Offcanvas

### DIFF
--- a/src/Offcanvas/Offcanvas.d.ts
+++ b/src/Offcanvas/Offcanvas.d.ts
@@ -9,7 +9,7 @@ export interface OffcanvasProps extends HTMLAttributes<HTMLDivElement> {
   fade?: boolean;
   header?: string;
   isOpen: boolean;
-  keyboard: boolean;
+  keyboard?: boolean;
   placement?: Placement;
   scroll?: boolean;
   sm?: boolean;


### PR DESCRIPTION
**Why these changes?**
The prop comes with a default value so it should be typed as optional.