### PR TITLE
🐛 fix(types): use correct ColumnProps in Label

### DIFF
--- a/src/Col/Col.d.ts
+++ b/src/Col/Col.d.ts
@@ -1,7 +1,7 @@
 import { SvelteComponent } from 'svelte';
 import { HTMLAttributes } from 'svelte/elements';
 
-declare type ColumnProps =
+export declare type ColumnProps =
   | string
   | boolean
   | number

--- a/src/Col/index.d.ts
+++ b/src/Col/index.d.ts
@@ -1,1 +1,1 @@
-export { default as Col, ColProps as ColumnProps } from './Col';
+export { default as Col, ColumnProps } from './Col';


### PR DESCRIPTION
This fixes some incorrect typescript affecting Label.