### PR TITLE
fix(types): fix Input value property type

### DIFF
--- a/src/Input/Input.d.ts
+++ b/src/Input/Input.d.ts
@@ -18,6 +18,7 @@ type MixedElementProps = HTMLInputAttributes &
     theme?: string;
     type?: InputType;
     valid?: boolean;
+    value?: any;
   };
 
 type MixedTargetProps = {


### PR DESCRIPTION
The Input "value" property type ends up being narrower because of the intersection with HTMLTextareaAttributes, seems like the best way to fix this would be to explicitly any it.