### PR TITLE
fix(types): fix Input value property type #2

### DIFF
--- a/src/Input/Input.d.ts
+++ b/src/Input/Input.d.ts
@@ -2,24 +2,25 @@ import { SvelteComponent } from 'svelte';
 import { HTMLInputAttributes, HTMLSelectAttributes, HTMLTextareaAttributes } from 'svelte/elements';
 import { Color, InputType } from '../shared';
 
-type MixedElementProps = HTMLInputAttributes &
-  HTMLSelectAttributes &
-  HTMLTextareaAttributes & {
-    bsSize?: 'lg' | 'sm' | string;
-    color?: Color | string;
-    feedback?: string | string[];
-    files?: FileList;
-    group?: any;
-    inner?: HTMLElement;
-    invalid?: boolean;
-    label?: string;
-    plaintext?: boolean;
-    reverse?: boolean;
-    theme?: string;
-    type?: InputType;
-    valid?: boolean;
-    value?: any;
-  };
+interface MixedElementProps extends Omit<
+  HTMLInputAttributes & HTMLSelectAttributes & HTMLTextareaAttributes,
+  'value'
+> {
+  bsSize?: 'lg' | 'sm' | string;
+  color?: Color | string;
+  feedback?: string | string[];
+  files?: FileList;
+  group?: any;
+  inner?: HTMLElement;
+  invalid?: boolean;
+  label?: string;
+  plaintext?: boolean;
+  reverse?: boolean;
+  theme?: string;
+  type?: InputType;
+  valid?: boolean;
+  value?: any;
+};
 
 type MixedTargetProps = {
   checked: boolean;


### PR DESCRIPTION
The Input "value" property type ends up being narrower because of the intersection with HTMLTextareaAttributes, my earlier change did not really fix it, omit is the way to go, sorry for wasting your time.