### PR TITLE
🐛 fix(types): Allow "target" attribute for DropdownItem

### DIFF
--- a/src/DropdownItem/DropdownItem.d.ts
+++ b/src/DropdownItem/DropdownItem.d.ts
@@ -1,13 +1,16 @@
 import { SvelteComponent } from 'svelte';
-import { HTMLLiAttributes } from 'svelte/elements';
+import { HTMLButtonAttributes, HTMLAnchorAttributes, HTMLAttributes } from 'svelte/elements';
 
-export interface DropdownItemProps extends HTMLLiAttributes {
+interface MixedElementProps extends Omit<HTMLButtonAttributes & HTMLAnchorAttributes, 'target'> {}
+
+export interface DropdownItemProps extends MixedElementProps {
   active?: boolean;
   disabled?: boolean;
   divider?: boolean;
   header?: boolean;
   href?: string;
   toggle?: boolean;
+  target?: string | null;
 }
 
 export interface DropdownItemEvents {


### PR DESCRIPTION
This will resolve #63, and also any other anticipatory type issues with `$$restProps` being applied to the various inner elements of `DropdownItem.svelte`.

**Key Detail:** `$$restProps` isn't spread on the `<li>` — so I've dropped that part of the props interface.