### PR TITLE
🐛 fix(input): retain invalid text in number inputs

### DIFF
--- a/src/Input/Input.svelte
+++ b/src/Input/Input.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { tick } from 'svelte';
   import { FormCheck } from '../FormCheck';
   import { FormFeedback } from '../FormFeedback';
   import { classnames } from '../utils';
@@ -179,6 +180,10 @@
    */
   export let value = undefined;
 
+  let boundValue;
+  let bubblingValueChange;
+  $: update(value);
+
   let classes;
   let tag;
 
@@ -238,13 +243,25 @@
     });
   }
 
-  const handleInput = ({ target }) => {
-    if (target.type === 'number' || target.type === 'range') {
-      value = Number(target.value);
-    } else {
-      value = target.value;
+  function update(value) {
+    if (!bubblingValueChange) {
+      boundValue = value;
     }
-  };
+  }
+
+  function handleInput({ target }) {
+    let convertedValue = target.value;
+    if (type === 'number' || type === 'range') {
+      convertedValue = convertedValue !== '' ? +convertedValue : '';
+    }
+    if (value !== convertedValue) {
+      bubblingValueChange = true;
+      value = convertedValue;
+      tick().then(() => {
+        bubblingValueChange = false;
+      });
+    }
+  }
 </script>
 
 {#if tag === 'input'}
@@ -382,7 +399,7 @@
       {...{ type }}
       data-bs-theme={theme}
       class={classes}
-      bind:value
+      value={boundValue}
       bind:this={inner}
       on:blur
       on:change={handleInput}
@@ -425,7 +442,7 @@
       {disabled}
       {placeholder}
       {readonly}
-      {value}
+      value={boundValue}
     />
   {/if}
 {:else if tag === 'textarea'}


### PR DESCRIPTION
Number inputs are hard to type in. #61 introduced a bug as its implementation constantly overwrites value with the number parsed from the input.

The current behavior are less than desirable in the following ways.
1. Clearing the input by deleting its content fills it in with 0.
2. A trailing decimal point disappears immediately after being typed.
3. Non-numeric (invalid) text gets overwritten with 0.

I wasn't exactly sure what the intended interaction was with the use of `handleInput` and the one-way binding of `value` because I suspect it can simply be changed to `bind:value` without events. Let me know if I should make that change.

Note that empty string is provided as empty string and not NaN or null. Current behavior is to convert empty string to 0.