### PR TITLE
✨ Add "focus" and "blur" events to Button component

### DIFF
--- a/src/Button/Button.d.ts
+++ b/src/Button/Button.d.ts
@@ -20,6 +20,8 @@ export interface ButtonEvents {
   mouseover: WindowEventMap['mouseover'];
   mouseenter: WindowEventMap['mouseenter'];
   mouseleave: WindowEventMap['mouseleave'];
+  focus: WindowEventMap['focus'];
+  blur: WindowEventMap['blur'];
 }
 
 export interface ButtonSlots {

--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -110,6 +110,8 @@
     class:disabled
     bind:this={inner}
     on:click
+    on:focus
+    on:blur
     {href}
     aria-label={ariaLabel || defaultAriaLabel}
   >
@@ -126,6 +128,8 @@
     {disabled}
     bind:this={inner}
     on:click
+    on:focus
+    on:blur
     {value}
     aria-label={ariaLabel || defaultAriaLabel}
   >


### PR DESCRIPTION
**Why these changes?**

I noticed that these events were missing while using a Button within an InputGroup.