### PR TITLE
✨ feat(input): add "dblclick" event to Input component

### DIFF
--- a/src/Input/Input.d.ts
+++ b/src/Input/Input.d.ts
@@ -36,6 +36,7 @@ export interface InputEvents {
   blur: InputElementEvent<FocusEvent>;
   change: InputElementEvent<Event>;
   click: InputElementEvent<MouseEvent>;
+  dblclick: InputElementEvent<MouseEvent>;
   focus: InputElementEvent<FocusEvent>;
   input: InputElementEvent<InputEvent>;
   keydown: InputElementEvent<KeyboardEvent>;

--- a/src/Input/Input.svelte
+++ b/src/Input/Input.svelte
@@ -251,6 +251,7 @@
       on:blur
       on:change
       on:click
+      on:dblclick
       on:focus
       on:input
       on:keydown
@@ -275,6 +276,7 @@
       on:blur
       on:change
       on:click
+      on:dblclick
       on:focus
       on:input
       on:keydown
@@ -298,6 +300,7 @@
       on:blur
       on:change
       on:click
+      on:dblclick
       on:focus
       on:input
       on:keydown
@@ -379,6 +382,7 @@
       on:blur
       on:change
       on:click
+      on:dblclick
       on:focus
       on:input
       on:keydown
@@ -404,6 +408,7 @@
       on:blur
       on:change
       on:click
+      on:dblclick
       on:focus
       on:input
       on:keydown
@@ -427,6 +432,7 @@
     on:blur
     on:change
     on:click
+    on:dblclick
     on:focus
     on:input
     on:keydown


### PR DESCRIPTION
**Why these changes?**
"dblclick" event was missing from Input component.