### PR TITLE
🧹 Tidy imports within Image.stories.svelte

### DIFF
--- a/src/Image/Image.stories.svelte
+++ b/src/Image/Image.stories.svelte
@@ -1,5 +1,5 @@
 <script context="module">
-  import { Image as Images } from './Image.svelte';
+  import Image from './Image.svelte';
 
   export const meta = {
     title: 'Stories/Images',
@@ -57,7 +57,7 @@
 
 <script>
   import { Story, Template } from '@storybook/addon-svelte-csf';
-  import { Image, Figure } from '@sveltestrap/sveltestrap';
+  import { Figure } from '@sveltestrap/sveltestrap';
 
   const thumbnails = [
     'https://picsum.photos/100/100?random=' + Math.round(Math.random() * 1000),

--- a/src/Tabs/Tabs.stories.svelte
+++ b/src/Tabs/Tabs.stories.svelte
@@ -1,6 +1,6 @@
 <script context="module">
   export const meta = {
-    title: 'Stories/tabs',
+    title: 'Stories/Tabs',
     parameters: {},
     argTypes: {},
     args: {}


### PR DESCRIPTION
**Why these changes?**

Update story file for `<Image />` to be imported from the relative/local file.


Was doing some programmatic stuff and noticed this discrepancy with how the component is imported.
A lil tidying resolves it.

**Testing**
Changes performed via Github UI so I have not run tests.