### PR TITLE
🐛 fix ModalHeader for svelte 5

### DIFF
--- a/src/ModalHeader/ModalHeader.spec.js
+++ b/src/ModalHeader/ModalHeader.spec.js
@@ -5,7 +5,7 @@ const TestHarness = (props) => render(ModalHeader, props);
 
 describe('ModalHeader', () => {
   test('should render correctly', () => {
-    const { container } = TestHarness({ children: 'Zap' });
+    const { container } = TestHarness({ content: 'Zap' });
     const component = container.querySelector('.modal-header');
 
     expect(component.className).toBe('modal-header');

--- a/src/ModalHeader/ModalHeader.svelte
+++ b/src/ModalHeader/ModalHeader.svelte
@@ -26,15 +26,15 @@
    */
   export let id = undefined;
 
-  export let children = undefined;
+  export let content = undefined;
 
   $: classes = classnames(className, 'modal-header');
 </script>
 
 <div {...$$restProps} class={classes}>
   <h5 class="modal-title" {id}>
-    {#if children}
-      {children}
+    {#if content}
+      {content}
     {:else}
       <slot />
     {/if}


### PR DESCRIPTION
`children` is a reserved property in svelte 5
https://svelte.dev/docs/svelte/v5-migration-guide#The-children-prop-is-reserved

**Why these changes?**

because Modal doesn't work with svelte 5

when you do `<ModalHeader>test</ModalHeader>` with the old code in svelte 5, then the `children` prop will be defined and it will output it, but `children` is a snippet function which needs to be called and not `.toString()` of the function.

It seems this prop is only used for testing, so I just renamed it to a non reserved word.

**How do we test?**

`pnpm test`

**Screenshots**

Before:
![before](https://github.com/user-attachments/assets/723e72cd-daf2-429e-9d59-855db32ae3ee)

After:
![after](https://github.com/user-attachments/assets/e716824e-d052-4b94-b784-6c8864c2375d)

