### PR TITLE
 🐛  Rename children by content for svelte5 compatibility

### DIFF
--- a/src/Alert/Alert.spec.js
+++ b/src/Alert/Alert.spec.js
@@ -5,7 +5,7 @@ const TestHarness = (props) => render(Alert, props);
 
 describe('Alert', () => {
   test('should render with default color and text', () => {
-    const { container, queryByRole } = TestHarness({ children: 'Hello world!' });
+    const { container, queryByRole } = TestHarness({ content: 'Hello world!' });
     const alert = queryByRole('alert');
 
     expect(alert.innerHTML.trim()).toBe('Hello world!');
@@ -16,7 +16,7 @@ describe('Alert', () => {
   test('should render specified color', () => {
     const { container, queryByRole } = TestHarness({
       color: 'primary',
-      children: 'Hello world!'
+      content: 'Hello world!'
     });
 
     const alert = queryByRole('alert');
@@ -39,7 +39,7 @@ describe('Alert', () => {
   test('should render custom class', () => {
     const { container, queryByRole } = TestHarness({
       color: 'danger',
-      children: 'Hello world!',
+      content: 'Hello world!',
       class: 'boogie'
     });
 
@@ -52,7 +52,7 @@ describe('Alert', () => {
   test('should render dismissible alert', async () => {
     const { container, queryByRole, queryByLabelText } = TestHarness({
       color: 'info',
-      children: 'I can be dismissed!',
+      content: 'I can be dismissed!',
       dismissible: true
     });
 
@@ -81,7 +81,7 @@ describe('Alert', () => {
 
     const { rerender, queryByRole, queryByLabelText } = TestHarness({
       color: 'info',
-      children: 'I can be dismissed!',
+      content: 'I can be dismissed!',
       isOpen,
       toggle
     });
@@ -106,7 +106,7 @@ describe('Alert', () => {
   test('should render alert without fade', async () => {
     const { queryByRole, queryByLabelText } = TestHarness({
       color: 'info',
-      children: 'I can be dismissed!',
+      content: 'I can be dismissed!',
       dismissible: true,
       fade: false
     });
@@ -129,7 +129,7 @@ describe('Alert', () => {
   test('should render themed alert', async () => {
     const { container, queryByRole } = TestHarness({
       color: 'info',
-      children: 'I can be dismissed!',
+      content: 'I can be dismissed!',
       dismissible: true,
       fade: false,
       theme: 'light'

--- a/src/Alert/Alert.stories.svelte
+++ b/src/Alert/Alert.stories.svelte
@@ -16,7 +16,7 @@
           disable: true
         }
       },
-      children: {
+      content: {
         control: ''
       },
       closeClassName: {
@@ -103,7 +103,7 @@
     },
     args: {
       class: '',
-      children: undefined,
+      content: undefined,
       color: 'success',
       closeClassName: '',
       closeAriaLabel: 'Close',
@@ -130,7 +130,7 @@
   <Alert {...args} on:click></Alert>
 </Template>
 
-<Story name="Basic" args={{ children: "Hello, I'm a warning message.", color: 'warning' }} />
+<Story name="Basic" args={{ content: "Hello, I'm a warning message.", color: 'warning' }} />
 
 <Story name="Colors">
   {#each colors as color}

--- a/src/Alert/Alert.svelte
+++ b/src/Alert/Alert.svelte
@@ -14,7 +14,7 @@
    * The content to be displayed in the alert.
    * @type {any}
    */
-  export let children = undefined;
+  export let content = undefined;
 
   /**
    * ARIA label for the close button.
@@ -103,8 +103,8 @@
     {#if showClose}
       <button type="button" class={closeClassNames} aria-label={closeAriaLabel} on:click={handleToggle} />
     {/if}
-    {#if children}
-      {children}
+    {#if content}
+      {content}
     {:else}
       <slot />
     {/if}

--- a/src/Badge/Badge.spec.js
+++ b/src/Badge/Badge.spec.js
@@ -6,7 +6,7 @@ const TestHarness = (props) => render(Badge, props);
 describe('Badge', () => {
   test('should render text and default color', () => {
     const { container } = TestHarness({
-      children: 'Hello world!'
+      content: 'Hello world!'
     });
 
     const badge = container.querySelector('.badge');
@@ -20,7 +20,7 @@ describe('Badge', () => {
   test('should render specified color', () => {
     const { container } = TestHarness({
       color: 'primary',
-      children: 'Hello world!'
+      content: 'Hello world!'
     });
 
     const badge = container.querySelector('.badge');
@@ -33,7 +33,7 @@ describe('Badge', () => {
   test('should render custom class', () => {
     const { container } = TestHarness({
       color: 'danger',
-      children: 'Hello world!',
+      content: 'Hello world!',
       class: 'boogie'
     });
 
@@ -48,7 +48,7 @@ describe('Badge', () => {
   test('should render pill', () => {
     const { container } = TestHarness({
       pill: true,
-      children: 'Hello world!'
+      content: 'Hello world!'
     });
 
     const badge = container.querySelector('.badge');
@@ -61,7 +61,7 @@ describe('Badge', () => {
 
   test('should render link with href', () => {
     const { container } = TestHarness({
-      children: 'Hello World!',
+      content: 'Hello World!',
       href: 'http://example.com/'
     });
 
@@ -75,7 +75,7 @@ describe('Badge', () => {
   test('should render a positioned badge', () => {
     const { container } = TestHarness({
       positioned: true,
-      children: '100+',
+      content: '100+',
       ariaLabel: 'Unread messages'
     });
 

--- a/src/Badge/Badge.stories.svelte
+++ b/src/Badge/Badge.stories.svelte
@@ -25,7 +25,7 @@
           disable: true
         }
       },
-      children: {
+      content: {
         control: ''
       },
       color: {
@@ -87,7 +87,7 @@
       ariaLabel: '',
       border: false,
       class: '',
-      children: '',
+      content: '',
       color: 'primary',
       href: '',
       indicator: false,
@@ -115,7 +115,7 @@
   <Badge {...args} />
 </Template>
 
-<Story name="Basic" args={{ color: 'primary', children: 'Badge' }} source={basicSource} />
+<Story name="Basic" args={{ color: 'primary', content: 'Badge' }} source={basicSource} />
 
 <Story name="Colors">
   <div class="horizontal">

--- a/src/Badge/Badge.svelte
+++ b/src/Badge/Badge.svelte
@@ -28,7 +28,7 @@
    * @type {string}
    * @default ''
    */
-  export let children = '';
+  export let content = '';
 
   /**
    * The color theme for the badge.
@@ -101,8 +101,8 @@
 
 {#if href}
   <a {...$$restProps} {href} class={classes} data-bs-theme={theme}>
-    {#if children}
-      {children}
+    {#if content}
+      {content}
     {:else}
       <slot />
     {/if}
@@ -112,8 +112,8 @@
   </a>
 {:else}
   <span {...$$restProps} class={classes} data-bs-theme={theme}>
-    {#if children}
-      {children}
+    {#if content}
+      {content}
     {:else}
       <slot />
     {/if}

--- a/src/Breadcrumb/Breadcrumb.stories.svelte
+++ b/src/Breadcrumb/Breadcrumb.stories.svelte
@@ -16,7 +16,7 @@
           disable: true
         }
       },
-      children: {
+      content: {
         control: ''
       },
       divider: {
@@ -43,7 +43,7 @@
     },
     args: {
       class: '',
-      children: '',
+      content: '',
       divider: '/',
       listClassName: '',
       style: ''

--- a/src/Breadcrumb/Breadcrumb.svelte
+++ b/src/Breadcrumb/Breadcrumb.svelte
@@ -14,7 +14,7 @@
    * The content to be displayed within the breadcrumb.
    * @type {string}
    */
-  export let children = '';
+  export let content = '';
 
   /**
    * Custom divider character or string for the breadcrumb items.
@@ -42,8 +42,8 @@
 
 <nav style={styles} {...$$restProps} class={className}>
   <ol class={listClasses}>
-    {#if children}
-      {children}
+    {#if content}
+      {content}
     {:else}
       <slot />
     {/if}

--- a/src/BreadcrumbItem/BreadcrumbItem.spec.js
+++ b/src/BreadcrumbItem/BreadcrumbItem.spec.js
@@ -5,7 +5,7 @@ const TestHarness = (props) => render(BreadcrumbItem, props);
 
 describe('BreadcrumbItem', () => {
   test('should render correctly', () => {
-    const { container } = TestHarness({ children: 'Alpha' });
+    const { container } = TestHarness({ content: 'Alpha' });
     const item = container.querySelector('.breadcrumb-item');
 
     expect(item.innerHTML).toBe('Alpha');

--- a/src/BreadcrumbItem/BreadcrumbItem.svelte
+++ b/src/BreadcrumbItem/BreadcrumbItem.svelte
@@ -21,14 +21,14 @@
    * @type {string}
    * @default ''
    */
-  export let children = '';
+  export let content = '';
 
   $: classes = classnames(className, active ? 'active' : false, 'breadcrumb-item');
 </script>
 
 <li {...$$restProps} class={classes} aria-current={active ? 'page' : undefined}>
-  {#if children}
-    {children}
+  {#if content}
+    {content}
   {:else}
     <slot />
   {/if}

--- a/src/Button/Button.spec.js
+++ b/src/Button/Button.spec.js
@@ -5,7 +5,7 @@ const TestHarness = (props) => render(Button, props);
 
 describe('Button', () => {
   test('should render text and default color', () => {
-    const { container } = TestHarness({ children: 'Hello world!' });
+    const { container } = TestHarness({ content: 'Hello world!' });
     const button = container.querySelector('.btn');
 
     expect(button.innerHTML).toBe('Hello world!');

--- a/src/Button/Button.stories.svelte
+++ b/src/Button/Button.stories.svelte
@@ -16,7 +16,7 @@
           disable: true
         }
       },
-      children: {
+      content: {
         control: ''
       },
       active: {
@@ -75,7 +75,7 @@
       class: '',
       active: false,
       block: false,
-      children: undefined,
+      content: undefined,
       close: false,
       color: 'secondary',
       disabled: false,
@@ -105,7 +105,7 @@
   <Button {...args} on:click></Button>
 </Template>
 
-<Story name="Basic" args={{ size: 'md', color: 'primary', children: 'Button' }} />
+<Story name="Basic" args={{ size: 'md', color: 'primary', content: 'Button' }} />
 
 <Story name="Colors" args={{ color: 'primary' }}>
   <div class="horizontal capitalize">

--- a/src/Button/Button.svelte
+++ b/src/Button/Button.svelte
@@ -28,7 +28,7 @@
    * @type {string}
    * @default ''
    */
-  export let children = '';
+  export let content = '';
 
   /**
    * Indicates if the button is a close button.
@@ -115,8 +115,8 @@
     {href}
     aria-label={ariaLabel || defaultAriaLabel}
   >
-    {#if children}
-      {children}
+    {#if content}
+      {content}
     {:else}
       <slot />
     {/if}
@@ -134,8 +134,8 @@
     aria-label={ariaLabel || defaultAriaLabel}
   >
     <slot>
-      {#if children}
-        {children}
+      {#if content}
+        {content}
       {:else}
         <slot />
       {/if}

--- a/src/ModalHeader/ModalHeader.spec.js
+++ b/src/ModalHeader/ModalHeader.spec.js
@@ -5,7 +5,7 @@ const TestHarness = (props) => render(ModalHeader, props);
 
 describe('ModalHeader', () => {
   test('should render correctly', () => {
-    const { container } = TestHarness({ children: 'Zap' });
+    const { container } = TestHarness({ content: 'Zap' });
     const component = container.querySelector('.modal-header');
 
     expect(component.className).toBe('modal-header');

--- a/src/ModalHeader/ModalHeader.svelte
+++ b/src/ModalHeader/ModalHeader.svelte
@@ -26,15 +26,15 @@
    */
   export let id = undefined;
 
-  export let children = undefined;
+  export let content = undefined;
 
   $: classes = classnames(className, 'modal-header');
 </script>
 
 <div {...$$restProps} class={classes}>
   <h5 class="modal-title" {id}>
-    {#if children}
-      {children}
+    {#if content}
+      {content}
     {:else}
       <slot />
     {/if}

--- a/src/OffcanvasHeader/OffcanvasHeader.spec.js
+++ b/src/OffcanvasHeader/OffcanvasHeader.spec.js
@@ -5,7 +5,7 @@ const TestHarness = (props) => render(OffcanvasHeader, props);
 
 describe('OffcanvasHeader', () => {
   test('should render correctly', () => {
-    const { container } = TestHarness({ children: 'Zap' });
+    const { container } = TestHarness({ content: 'Zap' });
     const component = container.querySelector('.offcanvas-header');
 
     expect(component.className).toBe('offcanvas-header');

--- a/src/OffcanvasHeader/OffcanvasHeader.svelte
+++ b/src/OffcanvasHeader/OffcanvasHeader.svelte
@@ -3,7 +3,7 @@
 
   let className = '';
   export { className as class };
-  export let children = undefined;
+  export let content = undefined;
   export let closeAriaLabel = 'Close';
   export let toggle = undefined;
 
@@ -12,8 +12,8 @@
 
 <div {...$$restProps} class={classes}>
   <h5 class="offcanvas-title">
-    {#if children}
-      {children}
+    {#if content}
+      {content}
     {:else}
       <slot />
     {/if}

--- a/src/Popover/Popover.spec.js
+++ b/src/Popover/Popover.spec.js
@@ -21,13 +21,13 @@ const POPOVER_POSITION_CLASS = {
 };
 
 beforeEach(() => {
-  renderButton({ children: 'Hello BTN' });
+  renderButton({ content: 'Hello BTN' });
 });
 
 describe('Popover test', () => {
   it('should render text and default placement(top)', () => {
     const containerPopover = renderPopover({
-      children: 'Hello',
+      content: 'Hello',
       target: 'btn',
       isOpen: true
     });
@@ -40,7 +40,7 @@ describe('Popover test', () => {
 
   it('should render text and left placement', () => {
     const containerPopover = renderPopover({
-      children: 'Hello',
+      content: 'Hello',
       target: 'btn',
       placement: 'left',
       isOpen: true

--- a/src/Popover/Popover.stories.svelte
+++ b/src/Popover/Popover.stories.svelte
@@ -13,7 +13,7 @@
       animation: {
         control: 'boolean'
       },
-      children: {
+      content: {
         control: ''
       },
       class: {
@@ -100,7 +100,7 @@
     },
     args: {
       animation: true,
-      children: '',
+      content: '',
       container: undefined,
       dismissible: false,
       hideOnOutsideClick: false,

--- a/src/Popover/Popover.svelte
+++ b/src/Popover/Popover.svelte
@@ -22,7 +22,7 @@
    * The content to be displayed within the popover.
    * @type {string}
    */
-  export let children = '';
+  export let content = '';
 
   /**
    * The container in which the popover should be rendered.
@@ -210,8 +210,8 @@
         <slot name="title">{title}</slot>
       </h3>
       <div class="popover-body">
-        {#if children}
-          {children}
+        {#if content}
+          {content}
         {:else}
           <slot />
         {/if}

--- a/src/Readme.md
+++ b/src/Readme.md
@@ -3,12 +3,12 @@
 This pattern is used to allow testing of Svelte slots:
 
 ```jsx
-{#if children}
-  {children}
+{#if content}
+  {content}
 {:else}
   <slot />
 {/if}
 ```
 
-Svelte componenent constructors do not support slots, so this adds a fake 'children' prop to allow. More info here:
+Svelte componenent constructors do not support slots, so this adds a fake 'content' prop to allow. More info here:
 https://github.com/testing-library/svelte-testing-library/issues/48

--- a/src/Tooltip/Tooltip.spec.js
+++ b/src/Tooltip/Tooltip.spec.js
@@ -13,7 +13,7 @@ const renderButton = (props) => {
 };
 
 beforeEach(() => {
-  renderButton({ children: 'Hello' });
+  renderButton({ content: 'Hello' });
 });
 
 const TOOLTIP_POSTION_CLASS = {
@@ -26,7 +26,7 @@ const TOOLTIP_POSTION_CLASS = {
 describe('Tooltip', () => {
   it('should render text and default placement(top)', () => {
     const containerTooltip = renderTooltip({
-      children: 'Hello world!',
+      content: 'Hello world!',
       target: 'btn',
       isOpen: true
     });
@@ -39,7 +39,7 @@ describe('Tooltip', () => {
 
   it('should render text and left placement', () => {
     const containerTooltip = renderTooltip({
-      children: 'Hello world!',
+      content: 'Hello world!',
       placement: 'left',
       target: 'btn',
       isOpen: true

--- a/src/Tooltip/Tooltip.stories.svelte
+++ b/src/Tooltip/Tooltip.stories.svelte
@@ -17,7 +17,7 @@
       animation: {
         control: 'boolean'
       },
-      children: {
+      content: {
         control: 'text'
       },
       container: {
@@ -74,7 +74,7 @@
     },
     args: {
       animation: true,
-      children: '',
+      content: '',
       container: undefined,
       delay: 0,
       id: '',

--- a/src/Tooltip/Tooltip.svelte
+++ b/src/Tooltip/Tooltip.svelte
@@ -22,7 +22,7 @@
    * The content to be displayed within the tooltip.
    * @type {string}
    */
-  export let children = '';
+  export let content = '';
 
   /**
    * The container in which the tooltip should be rendered.
@@ -227,8 +227,8 @@
     >
       <div class="tooltip-arrow" data-popper-arrow />
       <div class="tooltip-inner">
-        {#if children}
-          {children}
+        {#if content}
+          {content}
         {:else}
           <slot />
         {/if}


### PR DESCRIPTION
**Why these changes?**

Children is a protected keyword in svelte5, replace it by content to be able to use this library in svelte5 projects.

Fixes #100 

**How do we test?**

Run the test suite.
