### PR TITLE
🐛 fix(collapse): prevent animation on collapse

### DIFF
--- a/src/Collapse/Collapse.svelte
+++ b/src/Collapse/Collapse.svelte
@@ -15,52 +15,45 @@
   export let onEntered = () => dispatch('open');
   export let onExiting = () => dispatch('closing');
   export let onExited = () => dispatch('close');
-  export let expand = false;
   export let toggler = null;
+  let transitioning = false;
 
   onMount(() =>
-    toggle(toggler, (e) => {
-      isOpen = !isOpen;
-      e.preventDefault();
+    toggle(toggler, () => {
+      if (!transitioning) {
+        isOpen = !isOpen;
+      }
     })
   );
 
   $: classes = classnames(className, {
     'collapse-horizontal': horizontal,
-    'navbar-collapse': navbar
+    'navbar-collapse': navbar,
+    'd-none': !isOpen
   });
 
-  let windowWidth = 0;
-  let _wasMaximized = false;
-
-  // TODO wrong to hardcode these here - come from Bootstrap CSS only
-  const minWidth = {};
-  minWidth['xs'] = 0;
-  minWidth['sm'] = 576;
-  minWidth['md'] = 768;
-  minWidth['lg'] = 992;
-  minWidth['xl'] = 1200;
-
-  function notify() {
-    dispatch('update', isOpen);
+  function _onEntering(event) {
+    transitioning = true;
+    onEntering(event);
   }
 
-  $: if (navbar && expand) {
-    if (windowWidth >= minWidth[expand] && !isOpen) {
-      isOpen = true;
-      _wasMaximized = true;
-      notify();
-    } else if (windowWidth < minWidth[expand] && _wasMaximized) {
-      isOpen = false;
-      _wasMaximized = false;
-      notify();
-    }
+  function _onEntered(event) {
+    transitioning = false;
+    onEntered(event);
+  }
+
+  function _onExiting(event) {
+    transitioning = true;
+    onExiting(event);
+  }
+
+  function _onExited(event) {
+    transitioning = false;
+    onExited(event);
   }
 </script>
 
-<svelte:window bind:innerWidth={windowWidth} />
-
-{#if isOpen}
+{#key isOpen}
   <div
     style={navbar ? undefined : 'overflow: hidden;'}
     {...$$restProps}
@@ -71,11 +64,11 @@
     on:introend
     on:outrostart
     on:outroend
-    on:introstart={onEntering}
-    on:introend={onEntered}
-    on:outrostart={onExiting}
-    on:outroend={onExited}
+    on:introstart={_onEntering}
+    on:introend={_onEntered}
+    on:outrostart={_onExiting}
+    on:outroend={_onExited}
   >
     <slot />
   </div>
-{/if}
+{/key}


### PR DESCRIPTION
**Why these changes?**
This prevents the open animation from being triggered while the navigation bar is collapsed.
If isOpen was set to false and the navbar was collapsed, the animation to close the navbar was played.

This is an implementation of code changes that were made in https://github.com/bestguy/sveltestrap/pull/457.

Fixes #62 
