### PR TITLE
🐛 fix(modal): don't hide the modal before the outro transition is complete

### DIFF
--- a/src/transitions.js
+++ b/src/transitions.js
@@ -96,7 +96,7 @@ export function modalOut(node) {
   return {
     duration,
     tick: (t) => {
-      if (t === 1) {
+      if (t === 0) {
         node.style.display = 'none';
       }
     }


### PR DESCRIPTION
**Why these changes?**

The fade out transition for my modals did not work for me. My modal disappeared instantly without any transition. I've noticed that `modalOut` sets `display: none` at `t === 1` which is the start of the outro transition (see [Svelte 4 docs](https://v4.svelte.dev/docs/element-directives#custom-transition-functions), [Svelte 5 docs](https://svelte.dev/tutorial/svelte/custom-css-transitions))

**How do we test?**

I'm not really sure how to reproduce this/why it works in the documentation. But you can test that in Storybook that the modal outro transition is still working with this change.
