### PR TITLE
🐛 bugfix(transitions): make transitions compatible with prefers-reduced-motion in svelte 5

### DIFF
--- a/src/transitions.js
+++ b/src/transitions.js
@@ -5,6 +5,10 @@ export function backdropIn(node) {
 
   const duration = getTransitionDuration(node);
 
+  if (duration === 0) {
+    node.classList.add('show');
+  }
+
   return {
     duration,
     tick: (t) => {
@@ -18,6 +22,10 @@ export function backdropIn(node) {
 export function backdropOut(node) {
   node.classList.remove('show');
   const duration = getTransitionDuration(node);
+
+  if (duration === 0) {
+    node.style.display = 'none';
+  }
 
   return {
     duration,
@@ -35,6 +43,11 @@ export function collapseOut(node, params) {
   node.classList.add('collapsing');
   node.classList.remove('collapse', 'show');
   const duration = getTransitionDuration(node);
+
+  if (duration === 0) {
+    node.classList.remove('collapsing');
+    node.classList.add('collapse');
+  }
 
   return {
     duration,
@@ -56,6 +69,12 @@ export function collapseIn(node, params) {
   node.classList.remove('collapse', 'show');
   node.style[dimension] = 0;
   const duration = getTransitionDuration(node);
+
+  if (duration === 0) {
+    node.classList.remove('collapsing');
+    node.classList.add('collapse', 'show');
+    node.style[dimension] = '';
+  }
 
   return {
     duration,
@@ -79,6 +98,10 @@ export function modalIn(node) {
   node.style.display = 'block';
   const duration = getTransitionDuration(node);
 
+  if (duration === 0) {
+    node.classList.add('show');
+  }
+
   return {
     duration,
     tick: (t) => {
@@ -92,6 +115,10 @@ export function modalIn(node) {
 export function modalOut(node) {
   node.classList.remove('show');
   const duration = getTransitionDuration(node);
+
+  if (duration === 0) {
+    node.style.display = 'none';
+  }
 
   return {
     duration,


### PR DESCRIPTION
**Why these changes?**
Apparently, the behavior of transitions in Svelte 5 has changed slightly. Previously, if the user prefers reduced motion ([prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)), the `tick` callback was always called for the initial and final states. In Svelte 5, however, this is no longer called if the `duration` of the transition is 0. As a result, elements that used affected transitions could no longer become visible/invisible. To restore compatibility with Svelte 5, if the duration is 0, the designated end state is set directly.

This PR would close #128 

**How do we test?**

To reproduce the initial error you can simply use this playground app, before doing that you have to tell your browser to reduce the motion (Mozilla describes [here](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#user_preferences) how to do that on various systems)
- [Svelte 5 Version (not working)](https://svelte.dev/playground/untitled?version=5.39.11#H4sIAAAAAAAAE5VUwVLbMBD9lUUXoAMxHLgYh6G00-mhnR44Nj0o0ibZQZZcaQ3NZPLvXVkBTBoOnYxj6Wn36b2V1hvldYuqVveP6BjhCrqIC4zpPKLtDdrzNjAFD2lYTxx1B_LnE2U4qTO1IIdJ1T83itddpsqA4Dvij103KcmCzXXCQ7gJntGz0KhmhdrezPyMG0f-ASK66UwlXssuK0SeKViJRMFWzF2qq2oeAqcnzWY1MaGtrioTUhsKnPVOWvITk9JMVcLbVM8byK9JJlLH4LRfCiNLzLB1fqjtQmTYDHO-65mDPyuT78FqNx5_FUqMY-Qu2PV4_kXUYMzAFhYxtHB8OyppNRofXw_a2CFD6NDDFBbaJcwwS6ESA4fl0qEsnJzC9AY2u7Cj_L7eZo_F1-CysfRY6lk8gAkuRHFrxbRIUhB8bRyZh-mmEG9vfmTCQTdcNlXJKxwFpJQjpsPGW3hJK36bUUle10oik_hqqlHEm6RctR0w428hYgvUpb4FmzWDXDqQ28NnkOuAhpH7CNpSR4kM-SWgI1lNaCUDkHq5CBYY81ECeUOWbO8Z-nzkc-EHKfLAjc-7tnrpNWhHv3s92Wmr9sU1ozN90btf3y5Sq-P6YIE_B7gP4mQlot8U-BCROA3evkf1SXuDbo9kJ3mkcIcMHbC7EXL9c1sNy7ctWtJwcrj9ayjz09wOAB_KC0B7sZgDzm0fdYm8mFxctgmOSv9oz9f7sSSaysgEOY0aLv-Nfv3G_Be1RafX7wVKZ5TmGFzLZ4fxD6uaY4_bXzLT5J7IW1UP_bb9C8S8qGQcBQAA)
- [Svelte 4 Version (Working)](https://svelte.dev/playground/untitled?version=4.2.20#H4sIAAAAAAAAE5VUwVLbMBD9lUUXoAMxHLgYh6G00-mhnR44Nj0o0ibZQZZcaQ3NZPLvXVkBTBoOnYxj6Wn36b2V1hvldYuqVveP6BjhCrqIC4zpPKLtDdrzNjAFD2lYTxx1B_LnE2U4qTO1IIdJ1T83itddpsqA4Dvij103KcmCzXXCQ7gJntGz0KhmhdrezPyMG0f-ASK66UwlXssuK0SeKViJRMFWzF2qq2oeAqcnzWY1MaGtrioTUhsKnPVOWvITk9JMVcLbVM8byK9JJlLH4LRfCiNLzLB1fqjtQmTYDHO-65mDPyuT78FqNx5_FUqMY-Qu2PV4_kXUYMzAFhYxtHB8OyppNRofXw_a2CFD6NDDFBbaJcwwS6ESA4fl0qEsnJzC9AY2u7Cj_L7eZo_F1-CysfRY6lk8gAkuRHFrxbRIUhB8bRyZh-mmEG9vfmTCQTdcNlXJKxwFpJQjpsPGW3hJK36bUUle10oik_hqqlHEm6RctR0w428hYgvUpb4FmzWDXDqQ28NnkOuAhpH7CNpSR4kM-SWgI1lNaCUDkHq5CBYY81ECeUOWbO8Z-nzkc-EHKfLAjc-7tnrpNWhHv3s92Wmr9sU1ozN90btf3y5Sq-P6YIE_B7gP4mQlot8U-BCROA3evkf1SXuDbo9kJ3mkcIcMHbC7EXL9c1sNy7ctWtJwcrj9ayjz09wOAB_KC0B7sZgDzm0fdYm8mFxctgmOSv9oz9f7sSSaysgEOY0aLv-Nfv3G_Be1RafX7wVKZ5TmGFzLZ4fxD6uaY4_bXzLT5J7IW1UP_bb9C8S8qGQcBQAA)

Directly testing it using the stories is not that simple since it would require upgrading sveltestrap to svelte 5 but you could include sveltestrap in a svelte 5 project and see that it is working after the introduced changes.

**Screenshots**
This PR does not introduce any visible changes (except that modals and other items that use transitions work again)

