### PR TITLE
✨ Modal: On Open, prevent padding adjustment if scrollbar gutter is stable

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -19,7 +19,11 @@ export function getScrollbarWidth() {
 }
 
 export function setScrollbarWidth(padding) {
-  document.body.style.paddingRight = padding > 0 ? `${padding}px` : null;
+    const gutters = [getComputedStyle(document.body).scrollbarGutter, getComputedStyle(document.body.parentElement).scrollbarGutter]
+    
+    if (!gutters.includes("stable")) {
+        document.body.style.paddingRight = padding > 0 ? `${padding}px` : null;
+    }
 }
 
 export function isBodyOverflowing() {


### PR DESCRIPTION
Add check for scrollbar gutter before setting padding.

**Why these changes?**
On Modal open it was double-padding, causing a shift to the viewport.

**How do we test?**
Manual test:
1. Set `scrollbar-gutter: stable` on a body element or parent `html` element
2. Open a modal
3. Observe scrollbar / right padding of document

